### PR TITLE
✨ [Feat] 구글 소셜로그인, auth 관련 기능 구현

### DIFF
--- a/src/main/java/verbly/spring/domain/auth/controller/AuthRestController.java
+++ b/src/main/java/verbly/spring/domain/auth/controller/AuthRestController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import verbly.spring.domain.auth.dto.response.AuthResponseDTO;
 import verbly.spring.domain.auth.exception.AuthHandler;
+import verbly.spring.domain.auth.service.AuthCommandService;
 import verbly.spring.global.common.code.ErrorStatus;
 import verbly.spring.global.common.code.SuccessStatus;
 import verbly.spring.global.common.response.ApiResponse;

--- a/src/main/java/verbly/spring/domain/auth/controller/AuthRestController.java
+++ b/src/main/java/verbly/spring/domain/auth/controller/AuthRestController.java
@@ -29,7 +29,6 @@ import verbly.spring.global.security.utils.SecurityUtils;
 public class AuthRestController {
     private final AuthCommandService authCommandService;
     private final JwtTokenProvider jwtTokenProvider;
-    private final CookieCsrfTokenRepository csrfTokenRepository;
 
     @PostMapping("/logout")
     @Operation(summary = "회원 로그아웃 API - JWT AccessToken 인증 필요",

--- a/src/main/java/verbly/spring/domain/auth/controller/AuthRestController.java
+++ b/src/main/java/verbly/spring/domain/auth/controller/AuthRestController.java
@@ -47,8 +47,8 @@ public class AuthRestController {
     )
 //    public ApiResponse<AuthResponseDTO.ReissueTokenResponseDTO> reissueAccessToken(HttpServletRequest request) {
 //        String refreshToken = JwtTokenProvider.resolveToken(request); // Authorization 헤더에서 Bearer 토큰을 추출
-    public void reissueAccessToken(HttpServletRequest request, HttpServletResponse response) {
-//    public ApiResponse<AuthResponseDTO.ReissueTokenResponseDTO> reissueAccessToken(HttpServletRequest request, HttpServletResponse response) {
+//    public void reissueAccessToken(HttpServletRequest request, HttpServletResponse response) {
+    public ApiResponse<AuthResponseDTO.ReissueTokenResponseDTO> reissueAccessToken(HttpServletRequest request, HttpServletResponse response) {
 
         String refreshToken = jwtTokenProvider.resolveRefreshToken(request);
         if (!StringUtils.hasText(refreshToken) || !jwtTokenProvider.isRefreshToken(refreshToken)) { // refreshToken == null은 !StringUtils.hasText(refreshToken)로 체크 가능
@@ -61,11 +61,9 @@ public class AuthRestController {
         addCookie(response, "accessToken", tokens.getAccessToken(), true, 60 * 60 * 4); // 4시간
 
         // 응답 바디 없이 204 No Content
-        response.setStatus(HttpServletResponse.SC_NO_CONTENT);
+//        response.setStatus(HttpServletResponse.SC_NO_CONTENT);
 
-//        return ApiResponse.onSuccess(tokens); // 테스트용
-
-//        return ApiResponse.onSuccess(response);
+        return ApiResponse.onSuccess(tokens); // 테스트용
     }
 
     private void addCookie(HttpServletResponse response, String name, String value, boolean httpOnly, int maxAgeInSeconds) {
@@ -73,7 +71,7 @@ public class AuthRestController {
                 .httpOnly(httpOnly)
                 .secure(true)
                 .path("/")
-                .domain("dnbn.site")
+                .domain("verbly.site")
                 .maxAge(maxAgeInSeconds)
                 .sameSite("Lax")
                 .build();

--- a/src/main/java/verbly/spring/domain/auth/controller/AuthRestController.java
+++ b/src/main/java/verbly/spring/domain/auth/controller/AuthRestController.java
@@ -1,0 +1,83 @@
+package verbly.spring.domain.auth.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import verbly.spring.domain.auth.dto.response.AuthResponseDTO;
+import verbly.spring.domain.auth.exception.AuthHandler;
+import verbly.spring.global.common.code.ErrorStatus;
+import verbly.spring.global.common.code.SuccessStatus;
+import verbly.spring.global.common.response.ApiResponse;
+import verbly.spring.global.security.jwt.JwtTokenProvider;
+import verbly.spring.global.security.utils.SecurityUtils;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/auth")
+public class AuthRestController {
+    private final AuthCommandService authCommandService;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final CookieCsrfTokenRepository csrfTokenRepository;
+
+    @PostMapping("/logout")
+    @Operation(summary = "회원 로그아웃 API - JWT AccessToken 인증 필요",
+            description = "JWT 인증된 유저가 로그아웃하는 API입니다.",
+            security = { @SecurityRequirement(name = "JWT TOKEN") }
+    )
+    public ResponseEntity<ApiResponse<Void>> logout(HttpServletResponse response) {
+        Long userId = SecurityUtils.getCurrentUserId();
+        authCommandService.logout(response, userId);
+        return ResponseEntity.status(SuccessStatus.USER_LOGOUT_SUCCESS.getHttpStatus()).body(ApiResponse.of(SuccessStatus.USER_LOGOUT_SUCCESS, null));
+    }
+
+    @PostMapping("/reissue")
+    @Operation(summary = "토큰 재발급 API - JWT RefreshToken 인증 필요",
+            description = "RefreshToken으로 AccessToken을 재발급받는 API입니다. AccessToken은 HttpOnly 쿠키로 내려줍니다."
+    )
+//    public ApiResponse<AuthResponseDTO.ReissueTokenResponseDTO> reissueAccessToken(HttpServletRequest request) {
+//        String refreshToken = JwtTokenProvider.resolveToken(request); // Authorization 헤더에서 Bearer 토큰을 추출
+    public void reissueAccessToken(HttpServletRequest request, HttpServletResponse response) {
+//    public ApiResponse<AuthResponseDTO.ReissueTokenResponseDTO> reissueAccessToken(HttpServletRequest request, HttpServletResponse response) {
+
+        String refreshToken = jwtTokenProvider.resolveRefreshToken(request);
+        if (!StringUtils.hasText(refreshToken) || !jwtTokenProvider.isRefreshToken(refreshToken)) { // refreshToken == null은 !StringUtils.hasText(refreshToken)로 체크 가능
+            throw new AuthHandler(ErrorStatus.INVALID_JWT_REFRESH_TOKEN); // TOKEN4002
+        }
+
+        AuthResponseDTO.ReissueTokenResponseDTO tokens = authCommandService.reissue(refreshToken);
+
+        // 어세스 토큰 재발급
+        addCookie(response, "accessToken", tokens.getAccessToken(), true, 60 * 60 * 4); // 4시간
+
+        // 응답 바디 없이 204 No Content
+        response.setStatus(HttpServletResponse.SC_NO_CONTENT);
+
+//        return ApiResponse.onSuccess(tokens); // 테스트용
+
+//        return ApiResponse.onSuccess(response);
+    }
+
+    private void addCookie(HttpServletResponse response, String name, String value, boolean httpOnly, int maxAgeInSeconds) {
+        ResponseCookie cookie = ResponseCookie.from(name, value)
+                .httpOnly(httpOnly)
+                .secure(true)
+                .path("/")
+                .domain("dnbn.site")
+                .maxAge(maxAgeInSeconds)
+                .sameSite("Lax")
+                .build();
+
+        response.addHeader("Set-Cookie", cookie.toString());
+    }
+}

--- a/src/main/java/verbly/spring/domain/auth/converter/AuthConverter.java
+++ b/src/main/java/verbly/spring/domain/auth/converter/AuthConverter.java
@@ -1,0 +1,11 @@
+package verbly.spring.domain.auth.converter;
+
+import verbly.spring.domain.auth.dto.response.AuthResponseDTO;
+
+public class AuthConverter {
+    public static AuthResponseDTO.ReissueTokenResponseDTO toReissueTokenResponseDTO(String accessToken) {
+        return AuthResponseDTO.ReissueTokenResponseDTO.builder()
+                .accessToken(accessToken)
+                .build();
+    }
+}

--- a/src/main/java/verbly/spring/domain/auth/dto/response/AuthResponseDTO.java
+++ b/src/main/java/verbly/spring/domain/auth/dto/response/AuthResponseDTO.java
@@ -13,7 +13,14 @@ public class AuthResponseDTO {
     public static class LoginResultDTO { // 소셜 로그인
         private String accessToken;
         private String refreshToken;
+
         private Long userId;
+
+        private String provider;
+        private String nickname;
+        private String profileImage;
+        private String email;
+
         private String status;
     }
 

--- a/src/main/java/verbly/spring/domain/auth/exception/AuthHandler.java
+++ b/src/main/java/verbly/spring/domain/auth/exception/AuthHandler.java
@@ -1,0 +1,10 @@
+package verbly.spring.domain.auth.exception;
+
+import verbly.spring.global.common.code.BaseErrorCode;
+import verbly.spring.global.common.exception.BaseException;
+
+public class AuthHandler extends BaseException {
+    public AuthHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/verbly/spring/domain/auth/service/AuthCommandService.java
+++ b/src/main/java/verbly/spring/domain/auth/service/AuthCommandService.java
@@ -1,0 +1,9 @@
+package verbly.spring.domain.auth.service;
+
+import jakarta.servlet.http.HttpServletResponse;
+import verbly.spring.domain.auth.dto.response.AuthResponseDTO;
+
+public interface AuthCommandService {
+    void logout(HttpServletResponse response, Long userId);
+    AuthResponseDTO.ReissueTokenResponseDTO reissue(String refreshToken);
+}

--- a/src/main/java/verbly/spring/domain/auth/service/AuthCommandServiceImpl.java
+++ b/src/main/java/verbly/spring/domain/auth/service/AuthCommandServiceImpl.java
@@ -6,6 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseCookie;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.stereotype.Service;
+import verbly.spring.domain.auth.converter.AuthConverter;
 import verbly.spring.domain.auth.dto.response.AuthResponseDTO;
 import verbly.spring.domain.auth.exception.AuthHandler;
 import verbly.spring.domain.user.entity.User;

--- a/src/main/java/verbly/spring/domain/auth/service/AuthCommandServiceImpl.java
+++ b/src/main/java/verbly/spring/domain/auth/service/AuthCommandServiceImpl.java
@@ -1,0 +1,89 @@
+package verbly.spring.domain.auth.service;
+
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseCookie;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.stereotype.Service;
+import verbly.spring.domain.auth.dto.response.AuthResponseDTO;
+import verbly.spring.domain.auth.exception.AuthHandler;
+import verbly.spring.domain.user.entity.User;
+import verbly.spring.domain.user.exception.UserHandler;
+import verbly.spring.domain.user.repository.UserRepository;
+import verbly.spring.global.common.code.ErrorStatus;
+import verbly.spring.global.security.auth.CustomUserDetails;
+import verbly.spring.global.security.jwt.JwtTokenProvider;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AuthCommandServiceImpl implements AuthCommandService {
+    private final UserRepository userRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    public void logout(HttpServletResponse response, Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+
+        // JWT를 로컬(localStorage, 쿠키 등)에서 직접 제거해야 로그아웃
+        ResponseCookie deleteAccessTokenCookie = ResponseCookie.from("accessToken", "")
+                .httpOnly(true)
+                .secure(true)
+                .path("/")
+                .domain("verbly.site")
+                .maxAge(0)
+                .sameSite("Lax")
+                .build();
+
+        // refreshToken 쿠키 삭제 (즉시 만료 설정)
+        ResponseCookie deleteRefreshTokenCookie = ResponseCookie.from("refreshToken", "")
+                .httpOnly(true)
+                .secure(true) // HTTPS 환경이라면 true
+                .path("/")
+                .domain("verbly.site") // 운영 도메인과 맞춰서 설정
+                .maxAge(0) // 즉시 만료
+                .sameSite("Lax")
+                .build();
+
+        response.addHeader("Set-Cookie", deleteAccessTokenCookie.toString());
+        response.addHeader("Set-Cookie", deleteRefreshTokenCookie.toString());
+//        response.addHeader("Set-Cookie", deleteCsrfCookie.toString());
+
+        log.info("유저 {} 로그아웃 처리 및 JWT 쿠키 삭제 완료", user.getId());
+    }
+
+    @Override
+    public AuthResponseDTO.ReissueTokenResponseDTO reissue(String refreshToken) {
+        // 1. RefreshToken 유효성 검사 (서명 및 토큰 타입까지 확인)
+        if (!jwtTokenProvider.isRefreshToken(refreshToken)) {
+            throw new AuthHandler(ErrorStatus.INVALID_JWT_REFRESH_TOKEN);
+        }
+
+        // 2. RefreshToken에서 subject(socialId) 추출
+        String socialId = jwtTokenProvider.getSubjectFromToken(refreshToken);
+
+        // 3. DB에서 해당 유저 조회 (예외 처리 포함)
+        User user = userRepository.findBySocialId(socialId)
+                .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+
+        CustomUserDetails customUserDetails = new CustomUserDetails(user);
+
+        // 4. AccessToken 새로 생성 (Authentication 객체 없이도 직접 생성 가능)
+//        String newAccessToken = jwtTokenProvider.generateAccessTokenFromSocialId(socialId);
+        String newAccessToken = jwtTokenProvider.generateAccessToken(
+                new UsernamePasswordAuthenticationToken(
+//                        socialId,
+//                        null,
+//                        user.getAuthorities()
+                        customUserDetails.getUsername(), // socialId
+                        null,
+                        customUserDetails.getAuthorities()
+                )
+        );
+
+        // 5. DTO 변환은 컨버터에 위임
+        return AuthConverter.toReissueTokenResponseDTO(newAccessToken);
+    }
+}

--- a/src/main/java/verbly/spring/domain/stats/entity/Stats.java
+++ b/src/main/java/verbly/spring/domain/stats/entity/Stats.java
@@ -1,9 +1,10 @@
-package verbly.spring.domain.user.entity;
+package verbly.spring.domain.stats.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
+import verbly.spring.domain.user.entity.User;
 import verbly.spring.domain.user.enums.Level;
 
 import java.time.LocalDate;

--- a/src/main/java/verbly/spring/domain/stats/exception/StatsHandler.java
+++ b/src/main/java/verbly/spring/domain/stats/exception/StatsHandler.java
@@ -1,7 +1,10 @@
 package verbly.spring.domain.stats.exception;
 
-public class StatsHandler extends RuntimeException {
-    public StatsHandler(String message) {
-        super(message);
+import verbly.spring.global.common.code.BaseErrorCode;
+import verbly.spring.global.common.exception.BaseException;
+
+public class StatsHandler extends BaseException {
+    public StatsHandler(BaseErrorCode errorCode) {
+        super(errorCode);
     }
 }

--- a/src/main/java/verbly/spring/domain/stats/exception/StatsHandler.java
+++ b/src/main/java/verbly/spring/domain/stats/exception/StatsHandler.java
@@ -1,0 +1,7 @@
+package verbly.spring.domain.stats.exception;
+
+public class StatsHandler extends RuntimeException {
+    public StatsHandler(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/verbly/spring/domain/stats/repository/StatsRepository.java
+++ b/src/main/java/verbly/spring/domain/stats/repository/StatsRepository.java
@@ -1,0 +1,10 @@
+package verbly.spring.domain.stats.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import verbly.spring.domain.stats.entity.Stats;
+
+import java.util.Optional;
+
+public interface StatsRepository extends JpaRepository<Stats, Long> {
+    Optional<Stats> findByUserId(Long userId);
+}

--- a/src/main/java/verbly/spring/domain/stats/service/StatsCommandService.java
+++ b/src/main/java/verbly/spring/domain/stats/service/StatsCommandService.java
@@ -1,0 +1,6 @@
+package verbly.spring.domain.stats.service;
+
+public interface StatsCommandService {
+    void markAttendance(Long userId, String timezone);
+    void gainPoint(Long userId, long amount);
+}

--- a/src/main/java/verbly/spring/domain/stats/service/StatsCommandServiceImpl.java
+++ b/src/main/java/verbly/spring/domain/stats/service/StatsCommandServiceImpl.java
@@ -1,0 +1,32 @@
+package verbly.spring.domain.stats.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import verbly.spring.domain.stats.entity.Stats;
+import verbly.spring.domain.stats.exception.StatsHandler;
+import verbly.spring.domain.stats.repository.StatsRepository;
+import verbly.spring.global.common.code.ErrorStatus;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class StatsCommandServiceImpl implements StatsCommandService {
+    private final StatsRepository statsRepository;
+
+    @Override
+    public void markAttendance(Long userId, String timezone) {
+        Stats stats = statsRepository.findByUserId(userId)
+                .orElseThrow(() -> new StatsHandler(ErrorStatus.STATS_NOT_FOUND));
+
+        stats.markAttendance(timezone);
+    }
+
+    @Override
+    public void gainPoint(Long userId, long amount) {
+        Stats stats = statsRepository.findByUserId(userId)
+                .orElseThrow(() -> new StatsHandler(ErrorStatus.STATS_NOT_FOUND));
+
+        stats.setPoint(stats.getPoint() + amount);
+    }
+}

--- a/src/main/java/verbly/spring/domain/user/controller/UserRestController.java
+++ b/src/main/java/verbly/spring/domain/user/controller/UserRestController.java
@@ -14,6 +14,7 @@ import org.springframework.web.multipart.MultipartFile;
 import verbly.spring.domain.user.dto.request.UserRequestDTO;
 import verbly.spring.domain.user.dto.response.UserResponseDTO;
 import verbly.spring.domain.user.entity.User;
+import verbly.spring.domain.user.service.UserCommandService;
 import verbly.spring.domain.user.service.UserQueryService;
 import verbly.spring.global.common.code.SuccessStatus;
 import verbly.spring.global.common.response.ApiResponse;

--- a/src/main/java/verbly/spring/domain/user/controller/UserRestController.java
+++ b/src/main/java/verbly/spring/domain/user/controller/UserRestController.java
@@ -36,7 +36,6 @@ public class UserRestController {
             security = @SecurityRequirement(name = "JWT TOKEN")
     )
     public ResponseEntity<ApiResponse<UserResponseDTO.OnboardingResultDTO>> onboard(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestPart("request") @Valid UserRequestDTO.OnboardingDTO request
     ) {
         Long userId = SecurityUtils.getCurrentUserId();
@@ -50,9 +49,7 @@ public class UserRestController {
             description = "JWT 인증된 유저가 자신의 정보를 조회하는 API입니다.",
             security = { @SecurityRequirement(name = "JWT TOKEN") }
     )
-    public ResponseEntity<ApiResponse<UserResponseDTO.UserInfoDTO>> getMyInfo(
-            @AuthenticationPrincipal CustomUserDetails userDetails
-    ) {
+    public ResponseEntity<ApiResponse<UserResponseDTO.UserInfoDTO>> getMyInfo() {
         Long userId = SecurityUtils.getCurrentUserId();
         UserResponseDTO.UserInfoDTO info = userQueryService.getUserInfo(userId);
         return ResponseEntity.status(SuccessStatus.USER_INFO_READ_SUCCESS.getHttpStatus())
@@ -64,7 +61,7 @@ public class UserRestController {
             description = "JWT 인증된 유저가 자신의 계정을 탈퇴(삭제)하는 API입니다.",
             security = { @SecurityRequirement(name = "JWT TOKEN") }
     )
-    public ResponseEntity<ApiResponse<Void>> deleteUser(@AuthenticationPrincipal CustomUserDetails userDetails) {
+    public ResponseEntity<ApiResponse<Void>> deleteUser() {
         Long userId = SecurityUtils.getCurrentUserId();
         userCommandService.deleteUser(userId);
         return ResponseEntity.status(SuccessStatus.USER_DELETE_SUCCESS.getHttpStatus())
@@ -80,7 +77,6 @@ public class UserRestController {
     public ResponseEntity<ApiResponse<UserResponseDTO.ProfileUpdateResultDTO>> updateMyPage(
             @RequestPart(value = "request") @Valid UserRequestDTO.ProfileUpdateDTO request,
             @Parameter(content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))
-            @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestPart(value = "profileImage", required = false) MultipartFile profileImage
     ) {
         Long userId = SecurityUtils.getCurrentUserId();

--- a/src/main/java/verbly/spring/domain/user/controller/UserRestController.java
+++ b/src/main/java/verbly/spring/domain/user/controller/UserRestController.java
@@ -11,6 +11,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+import verbly.spring.domain.user.converter.UserConverter;
 import verbly.spring.domain.user.dto.request.UserRequestDTO;
 import verbly.spring.domain.user.dto.response.UserResponseDTO;
 import verbly.spring.domain.user.entity.User;

--- a/src/main/java/verbly/spring/domain/user/controller/UserRestController.java
+++ b/src/main/java/verbly/spring/domain/user/controller/UserRestController.java
@@ -36,7 +36,7 @@ public class UserRestController {
             security = @SecurityRequirement(name = "JWT TOKEN")
     )
     public ResponseEntity<ApiResponse<UserResponseDTO.OnboardingResultDTO>> onboard(
-            @RequestPart("request") @Valid UserRequestDTO.OnboardingDTO request
+            @RequestBody @Valid UserRequestDTO.OnboardingDTO request
     ) {
         Long userId = SecurityUtils.getCurrentUserId();
         User user = userCommandService.onboardingUser(userId, request);
@@ -75,8 +75,8 @@ public class UserRestController {
             security = { @SecurityRequirement(name = "JWT TOKEN") }
     )
     public ResponseEntity<ApiResponse<UserResponseDTO.ProfileUpdateResultDTO>> updateMyPage(
-            @RequestPart(value = "request") @Valid UserRequestDTO.ProfileUpdateDTO request,
             @Parameter(content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))
+            @RequestPart(value = "request") @Valid UserRequestDTO.ProfileUpdateDTO request,
             @RequestPart(value = "profileImage", required = false) MultipartFile profileImage
     ) {
         Long userId = SecurityUtils.getCurrentUserId();

--- a/src/main/java/verbly/spring/domain/user/controller/UserRestController.java
+++ b/src/main/java/verbly/spring/domain/user/controller/UserRestController.java
@@ -20,6 +20,7 @@ import verbly.spring.domain.user.service.UserQueryService;
 import verbly.spring.global.common.code.SuccessStatus;
 import verbly.spring.global.common.response.ApiResponse;
 import verbly.spring.global.security.auth.CustomUserDetails;
+import verbly.spring.global.security.utils.SecurityUtils;
 
 @RestController
 @RequiredArgsConstructor
@@ -38,7 +39,7 @@ public class UserRestController {
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestPart("request") @Valid UserRequestDTO.OnboardingDTO request
     ) {
-        Long userId = userDetails.getUser().getId();
+        Long userId = SecurityUtils.getCurrentUserId();
         User user = userCommandService.onboardingUser(userId, request);
         return ResponseEntity.status(SuccessStatus.USER_ONBOARDING_SUCCESS.getHttpStatus())
                 .body(ApiResponse.of(SuccessStatus.USER_ONBOARDING_SUCCESS, UserConverter.toOnboardingResponseDTO(user)));
@@ -52,7 +53,7 @@ public class UserRestController {
     public ResponseEntity<ApiResponse<UserResponseDTO.UserInfoDTO>> getMyInfo(
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        Long userId = userDetails.getUser().getId();
+        Long userId = SecurityUtils.getCurrentUserId();
         UserResponseDTO.UserInfoDTO info = userQueryService.getUserInfo(userId);
         return ResponseEntity.status(SuccessStatus.USER_INFO_READ_SUCCESS.getHttpStatus())
                 .body(ApiResponse.of(SuccessStatus.USER_INFO_READ_SUCCESS, info));
@@ -64,7 +65,8 @@ public class UserRestController {
             security = { @SecurityRequirement(name = "JWT TOKEN") }
     )
     public ResponseEntity<ApiResponse<Void>> deleteUser(@AuthenticationPrincipal CustomUserDetails userDetails) {
-        userCommandService.deleteUser(userDetails.getUser().getId());
+        Long userId = SecurityUtils.getCurrentUserId();
+        userCommandService.deleteUser(userId);
         return ResponseEntity.status(SuccessStatus.USER_DELETE_SUCCESS.getHttpStatus())
                 .body(ApiResponse.of(SuccessStatus.USER_DELETE_SUCCESS, null));
     }
@@ -81,7 +83,7 @@ public class UserRestController {
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestPart(value = "profileImage", required = false) MultipartFile profileImage
     ) {
-        Long userId = userDetails.getUser().getId();
+        Long userId = SecurityUtils.getCurrentUserId();
         UserResponseDTO.ProfileUpdateResultDTO result = userCommandService.updateUser(userId, request, profileImage);
         return ResponseEntity.status(SuccessStatus.USER_PROFILE_UPDATE_SUCCESS.getHttpStatus())
                 .body(ApiResponse.of(SuccessStatus.USER_PROFILE_UPDATE_SUCCESS, result));

--- a/src/main/java/verbly/spring/domain/user/controller/UserRestController.java
+++ b/src/main/java/verbly/spring/domain/user/controller/UserRestController.java
@@ -71,7 +71,7 @@ public class UserRestController {
     @PatchMapping(consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
     @Operation(
             summary = "마이페이지 회원 정보 수정 API - JWT AccessToken 인증 필요",
-            description = "JWT 인증된 사용자가 프로필 이미지, 닉네임, bio, 이메일, 전화번호를 수정하는 API입니다.",
+            description = "JWT 인증된 유저가 프로필 이미지, 닉네임, bio, 이메일, 전화번호를 수정하는 API입니다.",
             security = { @SecurityRequirement(name = "JWT TOKEN") }
     )
     public ResponseEntity<ApiResponse<UserResponseDTO.ProfileUpdateResultDTO>> updateMyPage(

--- a/src/main/java/verbly/spring/domain/user/controller/UserRestController.java
+++ b/src/main/java/verbly/spring/domain/user/controller/UserRestController.java
@@ -14,6 +14,7 @@ import org.springframework.web.multipart.MultipartFile;
 import verbly.spring.domain.user.dto.request.UserRequestDTO;
 import verbly.spring.domain.user.dto.response.UserResponseDTO;
 import verbly.spring.domain.user.entity.User;
+import verbly.spring.domain.user.service.UserQueryService;
 import verbly.spring.global.common.code.SuccessStatus;
 import verbly.spring.global.common.response.ApiResponse;
 import verbly.spring.global.security.auth.CustomUserDetails;

--- a/src/main/java/verbly/spring/domain/user/controller/UserRestController.java
+++ b/src/main/java/verbly/spring/domain/user/controller/UserRestController.java
@@ -22,65 +22,65 @@ import verbly.spring.global.security.auth.CustomUserDetails;
 @RequiredArgsConstructor
 @RequestMapping("api/user")
 public class UserRestController {
-//    private final UserQueryService userQueryService;
-//    private final UserCommandService userCommandService;
-//
-//    @PostMapping("/onboarding")
-//    @Operation(
-//            summary = "회원 초기 정보 등록 (온보딩) API - JWT AccessToken 인증 필요",
-//            description = "JWT 인증된 유저가 nativeLang과 learningLang을 등록하는 API입니다.",
-//            security = @SecurityRequirement(name = "JWT TOKEN")
-//    )
-//    public ResponseEntity<ApiResponse<UserResponseDTO.OnboardingResultDTO>> onboard(
-//            @AuthenticationPrincipal CustomUserDetails userDetails,
-//            @RequestPart("request") @Valid UserRequestDTO.OnboardingDTO request
-//    ) {
-//        Long userId = userDetails.getUser().getId();
-//        User user = userCommandService.onboardingUser(userId, request);
-//        return ResponseEntity.status(SuccessStatus.USER_ONBOARDING_SUCCESS.getHttpStatus())
-//                .body(ApiResponse.of(SuccessStatus.USER_ONBOARDING_SUCCESS, UserConverter.toOnboardingResponseDTO(user)));
-//    }
-//
-//    @GetMapping("/me")
-//    @Operation(summary = "회원 정보 조회 API - JWT AccessToken 인증 필요",
-//            description = "JWT 인증된 유저가 자신의 정보를 조회하는 API입니다.",
-//            security = { @SecurityRequirement(name = "JWT TOKEN") }
-//    )
-//    public ResponseEntity<ApiResponse<UserResponseDTO.UserInfoDTO>> getMyInfo(
-//            @AuthenticationPrincipal CustomUserDetails userDetails
-//    ) {
-//        Long userId = userDetails.getUser().getId();
-//        UserResponseDTO.UserInfoDTO info = userQueryService.getUserInfo(userId);
-//        return ResponseEntity.status(SuccessStatus.USER_INFO_READ_SUCCESS.getHttpStatus())
-//                .body(ApiResponse.of(SuccessStatus.USER_INFO_READ_SUCCESS, info));
-//    }
-//
-//    @DeleteMapping
-//    @Operation(summary = "회원 탈퇴 API - JWT AccessToken 인증 필요",
-//            description = "JWT 인증된 유저가 자신의 계정을 탈퇴(삭제)하는 API입니다.",
-//            security = { @SecurityRequirement(name = "JWT TOKEN") }
-//    )
-//    public ResponseEntity<ApiResponse<Void>> deleteUser(@AuthenticationPrincipal CustomUserDetails userDetails) {
-//        userCommandService.deleteUser(userDetails.getUser().getId());
-//        return ResponseEntity.status(SuccessStatus.USER_DELETE_SUCCESS.getHttpStatus())
-//                .body(ApiResponse.of(SuccessStatus.USER_DELETE_SUCCESS, null));
-//    }
-//
-//    @PatchMapping(consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
-//    @Operation(
-//            summary = "마이페이지 회원 정보 수정 API - JWT AccessToken 인증 필요",
-//            description = "JWT 인증된 사용자가 프로필 이미지, 닉네임, bio, 이메일, 전화번호를 수정하는 API입니다.",
-//            security = { @SecurityRequirement(name = "JWT TOKEN") }
-//    )
-//    public ResponseEntity<ApiResponse<UserResponseDTO.ProfileUpdateResultDTO>> updateMyPage(
-//            @RequestPart(value = "request") @Valid UserRequestDTO.ProfileUpdateDTO request,
-//            @Parameter(content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))
-//            @AuthenticationPrincipal CustomUserDetails userDetails,
-//            @RequestPart(value = "profileImage", required = false) MultipartFile profileImage
-//    ) {
-//        Long userId = userDetails.getUser().getId();
-//        UserResponseDTO.ProfileUpdateResultDTO result = userCommandService.updateUser(userId, request, profileImage);
-//        return ResponseEntity.status(SuccessStatus.USER_PROFILE_UPDATE_SUCCESS.getHttpStatus())
-//                .body(ApiResponse.of(SuccessStatus.USER_PROFILE_UPDATE_SUCCESS, result));
-//    }
+    private final UserQueryService userQueryService;
+    private final UserCommandService userCommandService;
+
+    @PostMapping("/onboarding")
+    @Operation(
+            summary = "회원 초기 정보 등록 (온보딩) API - JWT AccessToken 인증 필요",
+            description = "JWT 인증된 유저가 nativeLang과 learningLang을 등록하는 API입니다.",
+            security = @SecurityRequirement(name = "JWT TOKEN")
+    )
+    public ResponseEntity<ApiResponse<UserResponseDTO.OnboardingResultDTO>> onboard(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestPart("request") @Valid UserRequestDTO.OnboardingDTO request
+    ) {
+        Long userId = userDetails.getUser().getId();
+        User user = userCommandService.onboardingUser(userId, request);
+        return ResponseEntity.status(SuccessStatus.USER_ONBOARDING_SUCCESS.getHttpStatus())
+                .body(ApiResponse.of(SuccessStatus.USER_ONBOARDING_SUCCESS, UserConverter.toOnboardingResponseDTO(user)));
+    }
+
+    @GetMapping("/me")
+    @Operation(summary = "회원 정보 조회 API - JWT AccessToken 인증 필요",
+            description = "JWT 인증된 유저가 자신의 정보를 조회하는 API입니다.",
+            security = { @SecurityRequirement(name = "JWT TOKEN") }
+    )
+    public ResponseEntity<ApiResponse<UserResponseDTO.UserInfoDTO>> getMyInfo(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long userId = userDetails.getUser().getId();
+        UserResponseDTO.UserInfoDTO info = userQueryService.getUserInfo(userId);
+        return ResponseEntity.status(SuccessStatus.USER_INFO_READ_SUCCESS.getHttpStatus())
+                .body(ApiResponse.of(SuccessStatus.USER_INFO_READ_SUCCESS, info));
+    }
+
+    @DeleteMapping
+    @Operation(summary = "회원 탈퇴 API - JWT AccessToken 인증 필요",
+            description = "JWT 인증된 유저가 자신의 계정을 탈퇴(삭제)하는 API입니다.",
+            security = { @SecurityRequirement(name = "JWT TOKEN") }
+    )
+    public ResponseEntity<ApiResponse<Void>> deleteUser(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        userCommandService.deleteUser(userDetails.getUser().getId());
+        return ResponseEntity.status(SuccessStatus.USER_DELETE_SUCCESS.getHttpStatus())
+                .body(ApiResponse.of(SuccessStatus.USER_DELETE_SUCCESS, null));
+    }
+
+    @PatchMapping(consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
+    @Operation(
+            summary = "마이페이지 회원 정보 수정 API - JWT AccessToken 인증 필요",
+            description = "JWT 인증된 사용자가 프로필 이미지, 닉네임, bio, 이메일, 전화번호를 수정하는 API입니다.",
+            security = { @SecurityRequirement(name = "JWT TOKEN") }
+    )
+    public ResponseEntity<ApiResponse<UserResponseDTO.ProfileUpdateResultDTO>> updateMyPage(
+            @RequestPart(value = "request") @Valid UserRequestDTO.ProfileUpdateDTO request,
+            @Parameter(content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestPart(value = "profileImage", required = false) MultipartFile profileImage
+    ) {
+        Long userId = userDetails.getUser().getId();
+        UserResponseDTO.ProfileUpdateResultDTO result = userCommandService.updateUser(userId, request, profileImage);
+        return ResponseEntity.status(SuccessStatus.USER_PROFILE_UPDATE_SUCCESS.getHttpStatus())
+                .body(ApiResponse.of(SuccessStatus.USER_PROFILE_UPDATE_SUCCESS, result));
+    }
 }

--- a/src/main/java/verbly/spring/domain/user/converter/UserConverter.java
+++ b/src/main/java/verbly/spring/domain/user/converter/UserConverter.java
@@ -37,9 +37,9 @@ public class UserConverter {
                 .point(user.getStats().getPoint())
                 .level(user.getStats().getLevel().getValue())
 //                .followCount(user.getFollowCount())
-//                .postCount(user.getPostCount())
-//                .correctionsGiven(user.getCorrectionsGiven())
-//                .correctionsReceived(user.getCorrectionsReceived())
+//                .postCount(postCount)
+//                .correctionsGiven(correctionsGiven)
+//                .correctionsReceived(correctionsReceived)
                 .status(user.getStatus().name())
                 .build();
     }

--- a/src/main/java/verbly/spring/domain/user/converter/UserConverter.java
+++ b/src/main/java/verbly/spring/domain/user/converter/UserConverter.java
@@ -35,7 +35,7 @@ public class UserConverter {
                 .phoneNumber(user.getPhoneNumber())
                 .streakDays(user.getStats().getStreakDays())
                 .point(user.getStats().getPoint())
-                .level(user.getStats().getLevel())
+                .level(user.getStats().getLevel().getValue())
                 .followCount(user.getFollowCount())
                 .postCount(user.getPostCount())
                 .correctionsGiven(user.getCorrectionsGiven())

--- a/src/main/java/verbly/spring/domain/user/converter/UserConverter.java
+++ b/src/main/java/verbly/spring/domain/user/converter/UserConverter.java
@@ -36,10 +36,10 @@ public class UserConverter {
                 .streakDays(user.getStats().getStreakDays())
                 .point(user.getStats().getPoint())
                 .level(user.getStats().getLevel().getValue())
-                .followCount(user.getFollowCount())
-                .postCount(user.getPostCount())
-                .correctionsGiven(user.getCorrectionsGiven())
-                .correctionsReceived(user.getCorrectionsReceived())
+//                .followCount(user.getFollowCount())
+//                .postCount(user.getPostCount())
+//                .correctionsGiven(user.getCorrectionsGiven())
+//                .correctionsReceived(user.getCorrectionsReceived())
                 .status(user.getStatus().name())
                 .build();
     }

--- a/src/main/java/verbly/spring/domain/user/converter/UserConverter.java
+++ b/src/main/java/verbly/spring/domain/user/converter/UserConverter.java
@@ -1,0 +1,46 @@
+package verbly.spring.domain.user.converter;
+
+import verbly.spring.domain.user.dto.response.UserResponseDTO;
+import verbly.spring.domain.user.entity.ProfileImage;
+import verbly.spring.domain.user.entity.User;
+
+public class UserConverter {
+    public static ProfileImage toProfileImage(String imageUrl, User user) {
+        return ProfileImage.builder()
+                .imageUrl(imageUrl)
+                .user(user)
+                .build();
+    }
+
+    public static UserResponseDTO.OnboardingResultDTO toOnboardingResponseDTO(User user) {
+        return UserResponseDTO.OnboardingResultDTO.builder()
+                .userId(user.getId())
+                .nickname(user.getNickname())
+                .profileImage(user.getProfileImage().getImageUrl())
+                .learningLang(user.getLearningLang())
+                .nativeLang(user.getNativeLang())
+                .status(user.getStatus().name())
+                .build();
+    }
+
+    public static UserResponseDTO.UserInfoDTO toUserInfoDTO(User user) {
+        return UserResponseDTO.UserInfoDTO.builder()
+                .userId(user.getId())
+                .learningLang(user.getLearningLang())
+                .nativeLang(user.getNativeLang())
+                .nickname(user.getNickname())
+                .profileImage(user.getProfileImage().getImageUrl())
+                .bio(user.getBio())
+                .email(user.getEmail())
+                .phoneNumber(user.getPhoneNumber())
+                .streakDays(user.getStats().getStreakDays())
+                .point(user.getStats().getPoint())
+                .level(user.getStats().getLevel())
+                .followCount(user.getFollowCount())
+                .postCount(user.getPostCount())
+                .correctionsGiven(user.getCorrectionsGiven())
+                .correctionsReceived(user.getCorrectionsReceived())
+                .status(user.getStatus().name())
+                .build();
+    }
+}

--- a/src/main/java/verbly/spring/domain/user/converter/UserConverter.java
+++ b/src/main/java/verbly/spring/domain/user/converter/UserConverter.java
@@ -43,4 +43,21 @@ public class UserConverter {
                 .status(user.getStatus().name())
                 .build();
     }
+
+    public static UserResponseDTO.ProfileUpdateResultDTO toProfileUpdateResultDTO(User user, String profileImageUrl) {
+        return UserResponseDTO.ProfileUpdateResultDTO.builder()
+                .userId(user.getId())
+                .nickname(user.getNickname())
+                .bio(user.getBio())
+                .email(user.getEmail())
+                .phoneNumber(user.getPhoneNumber())
+                .profileImage(
+                        profileImageUrl != null
+                                ? profileImageUrl
+                                : user.getProfileImage() != null
+                                ? user.getProfileImage().getImageUrl()
+                                : null
+                )
+                .build();
+    }
 }

--- a/src/main/java/verbly/spring/domain/user/dto/request/UserRequestDTO.java
+++ b/src/main/java/verbly/spring/domain/user/dto/request/UserRequestDTO.java
@@ -1,5 +1,6 @@
 package verbly.spring.domain.user.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.*;
 import lombok.Getter;
 import lombok.Setter;
@@ -10,10 +11,12 @@ public class UserRequestDTO {
     public static class OnboardingDTO {
         @NotBlank(message = "학습 언어는 필수입니다.")
         @Size(max = 3, message = "학습 언어 코드를 선택해주세요.")
+        @Schema(example = "en")
         private String learningLang; // "en"
 
         @NotEmpty(message = "모국어는 필수입니다.")
         @Size(max = 3, message = "모국어 코드를 선택해주세요.")
+        @Schema(example = "kr")
         private String nativeLang; // "ko"
     }
 
@@ -21,7 +24,7 @@ public class UserRequestDTO {
     @Setter
     public static class ProfileUpdateDTO {
         @NotBlank(message = "필수 입력칸 미입력입니다. 다시 확인해주세요.")
-        @Size(max = 50, message = "닉네임은 최대 50자입니다.")
+        @Size(max = 20, message = "닉네임은 최대 50자입니다.")
         private String nickname;
 
 //        String profileImage;
@@ -37,6 +40,7 @@ public class UserRequestDTO {
                 regexp = "^[0-9+\\-]{7,20}$",
                 message = "전화번호 형식이 올바르지 않습니다."
         )
+        @Schema(example = "+8201012345678")
         private String phoneNumber;
     }
 }

--- a/src/main/java/verbly/spring/domain/user/dto/response/UserResponseDTO.java
+++ b/src/main/java/verbly/spring/domain/user/dto/response/UserResponseDTO.java
@@ -41,8 +41,8 @@ public class UserResponseDTO {
         private int level;
 
         private long postCount;
-        private Long correctionsGiven; // 외국인에게만 뜨는 도움 준 수
-        private Long correctionsReceived; // 한국인에게만 뜨는 도움 받은 글
+        private long correctionsGiven; // 외국인에게만 뜨는 도움 준 수
+        private long correctionsReceived; // 한국인에게만 뜨는 도움 받은 글
 
         private String status;
     }

--- a/src/main/java/verbly/spring/domain/user/dto/response/UserResponseDTO.java
+++ b/src/main/java/verbly/spring/domain/user/dto/response/UserResponseDTO.java
@@ -56,6 +56,7 @@ public class UserResponseDTO {
         private Long userId;
         private String profileImage;
         private String nickname;
+        private String bio;
         private String email;
         private String phoneNumber;
     }

--- a/src/main/java/verbly/spring/domain/user/dto/response/UserResponseDTO.java
+++ b/src/main/java/verbly/spring/domain/user/dto/response/UserResponseDTO.java
@@ -38,7 +38,7 @@ public class UserResponseDTO {
         private int level;
 
 //        private long followCount;
-//        private long postCount;
+//        private long totalCount;
 //        private long correctionsGiven; // 외국인에게만 뜨는 도움 준 수
 //        private long correctionsReceived; // 한국인에게만 뜨는 도움 받은 글
 

--- a/src/main/java/verbly/spring/domain/user/dto/response/UserResponseDTO.java
+++ b/src/main/java/verbly/spring/domain/user/dto/response/UserResponseDTO.java
@@ -24,13 +24,10 @@ public class UserResponseDTO {
         private Long userId;
         private String nickname;
         private String profileImage;
-        private String chatId;
 
         private String bio;
         private String email;
         private String phoneNumber;
-
-        private long followCount;
 
         private String learningLang; // 학습 언어
         private String nativeLang; // 모국어
@@ -40,9 +37,10 @@ public class UserResponseDTO {
         private long point;
         private int level;
 
-        private long postCount;
-        private long correctionsGiven; // 외국인에게만 뜨는 도움 준 수
-        private long correctionsReceived; // 한국인에게만 뜨는 도움 받은 글
+//        private long followCount;
+//        private long postCount;
+//        private long correctionsGiven; // 외국인에게만 뜨는 도움 준 수
+//        private long correctionsReceived; // 한국인에게만 뜨는 도움 받은 글
 
         private String status;
     }

--- a/src/main/java/verbly/spring/domain/user/entity/ProfileImage.java
+++ b/src/main/java/verbly/spring/domain/user/entity/ProfileImage.java
@@ -6,6 +6,7 @@ import verbly.spring.global.common.entity.BaseEntity;
 
 @Entity
 @Getter
+@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder

--- a/src/main/java/verbly/spring/domain/user/entity/Stats.java
+++ b/src/main/java/verbly/spring/domain/user/entity/Stats.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
+import verbly.spring.domain.user.enums.Level;
 
 import java.time.LocalDate;
 import java.time.ZoneId;
@@ -62,5 +63,9 @@ public class Stats {
         }
 
         lastActiveDate = today;
+    }
+
+    public Level getLevel() {
+        return Level.fromPoint(this.point);
     }
 }

--- a/src/main/java/verbly/spring/domain/user/entity/Stats.java
+++ b/src/main/java/verbly/spring/domain/user/entity/Stats.java
@@ -20,6 +20,7 @@ public class Stats {
     @Id
     private Long userId;
 
+    @MapsId
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;

--- a/src/main/java/verbly/spring/domain/user/entity/Stats.java
+++ b/src/main/java/verbly/spring/domain/user/entity/Stats.java
@@ -47,6 +47,7 @@ public class Stats {
 
     private LocalDate lastActiveDate;
 
+    // home 조회 api에서 통계 서비스의 markAttendance 호출하기
     public void markAttendance(String timezone) {
         LocalDate today = LocalDate.now(ZoneId.of(timezone));
 

--- a/src/main/java/verbly/spring/domain/user/entity/User.java
+++ b/src/main/java/verbly/spring/domain/user/entity/User.java
@@ -77,4 +77,16 @@ public class User extends BaseEntity {
     public void updateNickname(String nickname) {
         this.nickname = nickname;
     }
+
+    public void updateBio(String bio) {
+        this.bio = bio;
+    }
+
+    public void updateEmail(String email) {
+        this.email = email;
+    }
+
+    public void updatePhoneNumber(String phoneNumber) {
+        this.phoneNumber = phoneNumber;
+    }
 }

--- a/src/main/java/verbly/spring/domain/user/entity/User.java
+++ b/src/main/java/verbly/spring/domain/user/entity/User.java
@@ -4,12 +4,10 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
+import verbly.spring.domain.stats.entity.Stats;
 import verbly.spring.domain.user.enums.AuthProvider;
 import verbly.spring.domain.user.enums.UserStatus;
 import verbly.spring.global.common.entity.BaseEntity;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Entity
 @Table(name = "users") // user는 예약어라 users로

--- a/src/main/java/verbly/spring/domain/user/entity/User.java
+++ b/src/main/java/verbly/spring/domain/user/entity/User.java
@@ -64,6 +64,16 @@ public class User extends BaseEntity {
     @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true) // 연관된 자식 엔티티가 부모에서 제거되었을 때, DB에서도 자동 삭제되도록
     private NotificationSettings notificationSettings;
 
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Stats stats;
+
+    public void setStats(Stats stats) {
+        this.stats = stats;
+        if (stats.getUser() != this) {
+            stats.setUser(this); // 양방향 연관관계 세팅
+        }
+    }
+
     public void updateNickname(String nickname) {
         this.nickname = nickname;
     }

--- a/src/main/java/verbly/spring/domain/user/entity/User.java
+++ b/src/main/java/verbly/spring/domain/user/entity/User.java
@@ -38,9 +38,8 @@ public class User extends BaseEntity {
     @Column(length = 3)
     private String learningLang; // ISO code (e.g. "en")
 
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    private UserStatus status; // ONBOARDING(소셜 로그인 직후), ACTIVE(온보딩 완료), SUSPENDED, DELETED
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true) // 연관된 자식 엔티티가 부모에서 제거되었을 때, DB에서도 자동 삭제되도록
+    private ProfileImage profileImage;
 
     @Column(length = 50)
     private String nickname;
@@ -48,18 +47,18 @@ public class User extends BaseEntity {
     @Column(columnDefinition = "TEXT") // 길이 제한 없도록
     private String bio;
 
-    //    private String profileImage;
-    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true) // 연관된 자식 엔티티가 부모에서 제거되었을 때, DB에서도 자동 삭제되도록
-    private ProfileImage profileImage;
-
-    @Column(length = 50)
-    private String timezone;
-
     @Column(length = 50)
     private String email;
 
     @Column(length = 20)
     private String phoneNumber; // +82 010-1234-5678
+
+    @Column(length = 50)
+    private String timezone;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private UserStatus status; // ONBOARDING(소셜 로그인 직후), ACTIVE(온보딩 완료), SUSPENDED, DELETED
 
     @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true) // 연관된 자식 엔티티가 부모에서 제거되었을 때, DB에서도 자동 삭제되도록
     private NotificationSettings notificationSettings;

--- a/src/main/java/verbly/spring/domain/user/enums/Level.java
+++ b/src/main/java/verbly/spring/domain/user/enums/Level.java
@@ -1,7 +1,17 @@
 package verbly.spring.domain.user.enums;
 
 public enum Level {
-    LV1, LV2, LV3, LV4, LV5, LV6, LV7;
+    LV1(1), LV2(2), LV3(3), LV4(4), LV5(5), LV6(6), LV7(7);
+
+    private final int value;
+
+    Level(int value) {
+        this.value = value;
+    }
+
+    public int getValue() {
+        return value;
+    }
 
     public static Level fromPoint(long point) {
         if (point <= 100) return LV1;

--- a/src/main/java/verbly/spring/domain/user/service/UserCommandService.java
+++ b/src/main/java/verbly/spring/domain/user/service/UserCommandService.java
@@ -1,0 +1,12 @@
+package verbly.spring.domain.user.service;
+
+import org.springframework.web.multipart.MultipartFile;
+import verbly.spring.domain.user.entity.User;
+import verbly.spring.domain.user.dto.request.UserRequestDTO;
+import verbly.spring.domain.user.dto.response.UserResponseDTO;
+
+public interface UserCommandService {
+    User onboardingUser(Long userId, UserRequestDTO.OnboardingDTO request);
+    void deleteUser(Long userId);
+    UserResponseDTO.ProfileUpdateResultDTO updateUser(Long userId, UserRequestDTO.ProfileUpdateDTO request, MultipartFile profileImage);
+}

--- a/src/main/java/verbly/spring/domain/user/service/UserCommandServiceImpl.java
+++ b/src/main/java/verbly/spring/domain/user/service/UserCommandServiceImpl.java
@@ -18,6 +18,7 @@ import verbly.spring.domain.user.repository.ProfileImageRepository;
 import verbly.spring.domain.user.repository.UserRepository;
 import verbly.spring.domain.uuid.entity.Uuid;
 import verbly.spring.domain.uuid.repository.UuidRepository;
+import verbly.spring.global.common.aws.s3.AmazonS3Manager;
 import verbly.spring.global.common.code.ErrorStatus;
 
 import java.util.List;
@@ -104,7 +105,7 @@ public class UserCommandServiceImpl implements UserCommandService {
                 .bio(user.getBio())
                 .email(user.getEmail())
                 .phoneNumber(user.getPhoneNumber())
-                .profileImageUrl(
+                .profileImage(
                         profileImageUrl != null
                                 ? profileImageUrl
                                 : user.getProfileImage() != null

--- a/src/main/java/verbly/spring/domain/user/service/UserCommandServiceImpl.java
+++ b/src/main/java/verbly/spring/domain/user/service/UserCommandServiceImpl.java
@@ -115,7 +115,6 @@ public class UserCommandServiceImpl implements UserCommandService {
                 .build();
     }
 
-    @ValidateS3ImageUpload
     private String updateProfileImage(User user, MultipartFile profileImage) {
         // 파일 형식 검사
         String contentType = profileImage.getContentType();

--- a/src/main/java/verbly/spring/domain/user/service/UserCommandServiceImpl.java
+++ b/src/main/java/verbly/spring/domain/user/service/UserCommandServiceImpl.java
@@ -46,6 +46,9 @@ public class UserCommandServiceImpl implements UserCommandService {
             throw new UserHandler(ErrorStatus.ONBOARDING_ALREADY_COMPLETED);
         }
 
+        user.setNativeLang(request.getNativeLang());
+        user.setLearningLang(request.getLearningLang());
+
         user.setStatus(UserStatus.ACTIVE); // 조건이 충족되지 않으면, user의 status는 기본값(NEED_ONBOARDING)인 채로 유지
 
         return user;

--- a/src/main/java/verbly/spring/domain/user/service/UserCommandServiceImpl.java
+++ b/src/main/java/verbly/spring/domain/user/service/UserCommandServiceImpl.java
@@ -7,6 +7,7 @@ import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+import verbly.spring.domain.user.converter.UserConverter;
 import verbly.spring.domain.user.dto.request.UserRequestDTO;
 import verbly.spring.domain.user.dto.response.UserResponseDTO;
 import verbly.spring.domain.user.entity.ProfileImage;

--- a/src/main/java/verbly/spring/domain/user/service/UserCommandServiceImpl.java
+++ b/src/main/java/verbly/spring/domain/user/service/UserCommandServiceImpl.java
@@ -1,0 +1,148 @@
+package verbly.spring.domain.user.service;
+
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import verbly.spring.domain.user.dto.request.UserRequestDTO;
+import verbly.spring.domain.user.dto.response.UserResponseDTO;
+import verbly.spring.domain.user.entity.ProfileImage;
+import verbly.spring.domain.user.entity.User;
+import verbly.spring.domain.user.enums.UserStatus;
+import verbly.spring.domain.user.exception.UserHandler;
+import verbly.spring.domain.user.repository.ProfileImageRepository;
+import verbly.spring.domain.user.repository.UserRepository;
+import verbly.spring.domain.uuid.entity.Uuid;
+import verbly.spring.domain.uuid.repository.UuidRepository;
+import verbly.spring.global.common.code.ErrorStatus;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserCommandServiceImpl implements UserCommandService {
+    private final UserRepository userRepository;
+    private final AmazonS3Manager s3Manager;
+    private final UuidRepository uuidRepository;
+    private final ProfileImageRepository profileImageRepository;
+//    private final OnboardingValidator onboardingValidator;
+
+    @Override
+    @Transactional // @Transactional에 의해 메서드 종료 시 변경 사항이 DB에 자동 반영
+    public User onboardingUser(Long userId, UserRequestDTO.OnboardingDTO request) {
+        // 기존 회원이 존재하는지를 따짐
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+
+        // 온보딩 완료 여부 체크
+        if (user.getStatus() != UserStatus.NEED_ONBOARDING) {
+            throw new UserHandler(ErrorStatus.ONBOARDING_ALREADY_COMPLETED);
+        }
+
+        user.setStatus(UserStatus.ACTIVE); // 조건이 충족되지 않으면, user의 status는 기본값(NEED_ONBOARDING)인 채로 유지
+
+        return user;
+    }
+
+    @Override
+    @Transactional
+    public void deleteUser(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+
+        // 멤버 테이블에서 멤버 삭제
+        userRepository.delete(user);
+    }
+
+    @Override
+    @Transactional
+    public UserResponseDTO.ProfileUpdateResultDTO updateUser(Long userId, UserRequestDTO.ProfileUpdateDTO request, MultipartFile profileImage) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+
+        if (user.getStatus() != UserStatus.NEED_ONBOARDING) {
+            throw new UserHandler(ErrorStatus.ONBOARDING_ALREADY_COMPLETED);
+        }
+
+        if (request.getNickname() == null || request.getNickname().trim().isEmpty()) {
+            throw new UserHandler(ErrorStatus.NICKNAME_NOT_EXIST);
+        }
+
+//        user.setNickname(request.getNickname());
+        user.updateNickname(request.getNickname()); // 도메인 주도 설계(Domain-Driven Design) 원칙에 부합하도록
+
+        if (request.getBio() != null) {
+            user.updateBio(request.getBio());
+        }
+
+        if (request.getEmail() != null) {
+            user.updateEmail(request.getEmail());
+        }
+
+        if (request.getPhoneNumber() != null) {
+            user.updatePhoneNumber(request.getPhoneNumber());
+        }
+
+        String profileImageUrl = null;
+        if (profileImage != null && !profileImage.isEmpty()) {
+            profileImageUrl = updateProfileImage(user, profileImage);
+        }
+
+        return UserResponseDTO.ProfileUpdateResultDTO.builder()
+                .userId(user.getId())
+                .nickname(user.getNickname())
+                .bio(user.getBio())
+                .email(user.getEmail())
+                .phoneNumber(user.getPhoneNumber())
+                .profileImageUrl(
+                        profileImageUrl != null
+                                ? profileImageUrl
+                                : user.getProfileImage() != null
+                                ? user.getProfileImage().getImageUrl()
+                                : null
+                )
+                .build();
+    }
+
+    @ValidateS3ImageUpload
+    private String updateProfileImage(User user, MultipartFile profileImage) {
+        // 파일 형식 검사
+        String contentType = profileImage.getContentType();
+        if (contentType == null || !contentType.startsWith("image/")) {
+            throw new UserHandler(ErrorStatus.INVALID_IMAGE_TYPE);
+        }
+
+        // 파일 용량 제한 (10MB)
+        long maxFileSize = 10 * 1024 * 1024;
+        if (profileImage.getSize() > maxFileSize) {
+            throw new UserHandler(ErrorStatus.IMAGE_FILE_TOO_LARGE);
+        }
+
+        // UUID 생성 후 저장
+        String uuidStr = UUID.randomUUID().toString();
+        Uuid uuid = uuidRepository.save(Uuid.builder().uuid(uuidStr).build());
+
+        // S3 업로드
+        String profileImageUrl = s3Manager.uploadFile(s3Manager.generateUserKeyName(uuid), profileImage);
+
+        if (user.getProfileImage() != null) {
+            // 기존 이미지의 키 추출 및 삭제
+            String oldKey = s3Manager.extractS3KeyFromUrl(user.getProfileImage().getImageUrl());
+            s3Manager.deleteFile(oldKey);
+
+            // update: 기존 엔티티에 새로운 URL만 set
+            user.getProfileImage().updateImageUrl(profileImageUrl);
+        } else {
+            // 새 이미지 insert
+            profileImageRepository.save(UserConverter.toProfileImage(profileImageUrl, user));
+        }
+
+        return profileImageUrl;
+    }
+}

--- a/src/main/java/verbly/spring/domain/user/service/UserCommandServiceImpl.java
+++ b/src/main/java/verbly/spring/domain/user/service/UserCommandServiceImpl.java
@@ -99,20 +99,7 @@ public class UserCommandServiceImpl implements UserCommandService {
             profileImageUrl = updateProfileImage(user, profileImage);
         }
 
-        return UserResponseDTO.ProfileUpdateResultDTO.builder()
-                .userId(user.getId())
-                .nickname(user.getNickname())
-                .bio(user.getBio())
-                .email(user.getEmail())
-                .phoneNumber(user.getPhoneNumber())
-                .profileImage(
-                        profileImageUrl != null
-                                ? profileImageUrl
-                                : user.getProfileImage() != null
-                                ? user.getProfileImage().getImageUrl()
-                                : null
-                )
-                .build();
+        return UserConverter.toProfileUpdateResultDTO(user, profileImageUrl);
     }
 
     private String updateProfileImage(User user, MultipartFile profileImage) {

--- a/src/main/java/verbly/spring/domain/user/service/UserQueryService.java
+++ b/src/main/java/verbly/spring/domain/user/service/UserQueryService.java
@@ -1,0 +1,7 @@
+package verbly.spring.domain.user.service;
+
+import verbly.spring.domain.user.dto.response.UserResponseDTO;
+
+public interface UserQueryService {
+    UserResponseDTO.UserInfoDTO getUserInfo(Long userId);
+}

--- a/src/main/java/verbly/spring/domain/user/service/UserQueryServiceImpl.java
+++ b/src/main/java/verbly/spring/domain/user/service/UserQueryServiceImpl.java
@@ -7,6 +7,7 @@ import verbly.spring.domain.user.dto.response.UserResponseDTO;
 import verbly.spring.domain.user.entity.User;
 import verbly.spring.domain.user.exception.UserHandler;
 import verbly.spring.domain.user.repository.UserRepository;
+import verbly.spring.domain.user.validator.ProfileValidator;
 import verbly.spring.global.common.code.ErrorStatus;
 import verbly.spring.global.security.jwt.JwtTokenProvider;
 
@@ -15,7 +16,7 @@ import verbly.spring.global.security.jwt.JwtTokenProvider;
 public class UserQueryServiceImpl implements UserQueryService {
     private final UserRepository userRepository;
     private final JwtTokenProvider jwtTokenProvider;
-    private final OnboardingValidator onboardingValidator;
+    private final ProfileValidator profileValidator;
 
     @Override
     @Transactional(readOnly = true)
@@ -26,7 +27,7 @@ public class UserQueryServiceImpl implements UserQueryService {
         User user = userRepository.findById(userId) // UserRepository 로부터 사용자 정보를 조회
                 .orElseThrow(()-> new UserHandler(ErrorStatus.USER_NOT_FOUND));
 
-        boolean complete = onboardingValidator.isCompleteOnboarding(user);
+        boolean complete = profileValidator.hasRequiredProfileInfo(user);
 
         return UserConverter.toUserInfoDTO(user, complete); // 정보 조회에 성공하면, 우리가 정의한 Response DTO인 MemberInfoDTO 로 반환
     }

--- a/src/main/java/verbly/spring/domain/user/service/UserQueryServiceImpl.java
+++ b/src/main/java/verbly/spring/domain/user/service/UserQueryServiceImpl.java
@@ -3,6 +3,7 @@ package verbly.spring.domain.user.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import verbly.spring.domain.user.converter.UserConverter;
 import verbly.spring.domain.user.dto.response.UserResponseDTO;
 import verbly.spring.domain.user.entity.User;
 import verbly.spring.domain.user.exception.UserHandler;
@@ -27,8 +28,6 @@ public class UserQueryServiceImpl implements UserQueryService {
         User user = userRepository.findById(userId) // UserRepository 로부터 사용자 정보를 조회
                 .orElseThrow(()-> new UserHandler(ErrorStatus.USER_NOT_FOUND));
 
-        boolean complete = profileValidator.hasRequiredProfileInfo(user);
-
-        return UserConverter.toUserInfoDTO(user, complete); // 정보 조회에 성공하면, 우리가 정의한 Response DTO인 MemberInfoDTO 로 반환
+        return UserConverter.toUserInfoDTO(user); // 정보 조회에 성공하면, 우리가 정의한 Response DTO인 UserInfoDTO 로 반환
     }
 }

--- a/src/main/java/verbly/spring/domain/user/service/UserQueryServiceImpl.java
+++ b/src/main/java/verbly/spring/domain/user/service/UserQueryServiceImpl.java
@@ -1,0 +1,32 @@
+package verbly.spring.domain.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import verbly.spring.domain.user.dto.response.UserResponseDTO;
+import verbly.spring.domain.user.entity.User;
+import verbly.spring.domain.user.repository.UserRepository;
+import verbly.spring.global.common.code.ErrorStatus;
+import verbly.spring.global.security.jwt.JwtTokenProvider;
+
+@Service
+@RequiredArgsConstructor
+public class UserQueryServiceImpl implements UserQueryService {
+    private final UserRepository userRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final OnboardingValidator onboardingValidator;
+
+    @Override
+    @Transactional(readOnly = true)
+    public UserResponseDTO.UserInfoDTO getUserInfo(Long userId){
+//        Authentication authentication = jwtTokenProvider.extractAuthentication(request); // 토큰을 파싱하고, Authentication 객체를 추출
+//        String socialId = authentication.getName(); // 추출해낸 인증 객체(Authentication)을 통해 사용자 정보를 가져온다.
+
+        User user = userRepository.findById(userId) // UserRepository 로부터 사용자 정보를 조회
+                .orElseThrow(()-> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+
+        boolean complete = onboardingValidator.isCompleteOnboarding(user);
+
+        return UserConverter.toUserInfoDTO(user, complete); // 정보 조회에 성공하면, 우리가 정의한 Response DTO인 MemberInfoDTO 로 반환
+    }
+}

--- a/src/main/java/verbly/spring/domain/user/service/UserQueryServiceImpl.java
+++ b/src/main/java/verbly/spring/domain/user/service/UserQueryServiceImpl.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import verbly.spring.domain.user.dto.response.UserResponseDTO;
 import verbly.spring.domain.user.entity.User;
+import verbly.spring.domain.user.exception.UserHandler;
 import verbly.spring.domain.user.repository.UserRepository;
 import verbly.spring.global.common.code.ErrorStatus;
 import verbly.spring.global.security.jwt.JwtTokenProvider;

--- a/src/main/java/verbly/spring/domain/user/service/UserQueryServiceImpl.java
+++ b/src/main/java/verbly/spring/domain/user/service/UserQueryServiceImpl.java
@@ -28,6 +28,10 @@ public class UserQueryServiceImpl implements UserQueryService {
         User user = userRepository.findById(userId) // UserRepository 로부터 사용자 정보를 조회
                 .orElseThrow(()-> new UserHandler(ErrorStatus.USER_NOT_FOUND));
 
-        return UserConverter.toUserInfoDTO(user); // 정보 조회에 성공하면, 우리가 정의한 Response DTO인 UserInfoDTO 로 반환
+//        long totalCount = postRepository.countByUserId(user.getId());
+//        long correctionsGiven = correctionRepository.countByUserId(user.getId());
+//        long correctionsReceived = feedbackRepository.countByUserId(user.getId());
+
+        return UserConverter.toUserInfoDTO(user);//, totalCount, correctionsGiven, correctionsReceived); // 정보 조회에 성공하면, 우리가 정의한 Response DTO인 UserInfoDTO 로 반환
     }
 }

--- a/src/main/java/verbly/spring/domain/user/validator/ProfileValidator.java
+++ b/src/main/java/verbly/spring/domain/user/validator/ProfileValidator.java
@@ -4,8 +4,8 @@ import org.springframework.stereotype.Component;
 import verbly.spring.domain.user.entity.User;
 
 @Component
-public class OnboardingValidator {
-    public boolean isCompleteOnboarding(User user) {
+public class ProfileValidator {
+    public boolean hasRequiredProfileInfo(User user) {
         boolean hasNickname = user.getNickname() != null && !user.getNickname().isBlank();
 
         return hasNickname;

--- a/src/main/java/verbly/spring/global/common/aws/s3/AmazonS3Manager.java
+++ b/src/main/java/verbly/spring/global/common/aws/s3/AmazonS3Manager.java
@@ -1,0 +1,52 @@
+package verbly.spring.global.common.aws.s3;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+import verbly.spring.domain.uuid.entity.Uuid;
+import verbly.spring.global.config.AmazonConfig;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AmazonS3Manager {
+    private final AmazonS3 amazonS3;
+    private final AmazonConfig amazonConfig;
+
+    public String uploadFile(String keyName, MultipartFile file) {
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentLength(file.getSize());
+        metadata.setContentType(file.getContentType()); // aws의 s3의 폴더의 파일에서 다운로드 말고 브라우저에서 사진 확인 가능
+        try {
+            amazonS3.putObject(new PutObjectRequest(amazonConfig.getBucket(), keyName, file.getInputStream(), metadata));
+        } catch (IOException e){
+            log.error("error at AmazonS3Manager uploadFile : {}", (Object) e.getStackTrace());
+        }
+
+        return amazonS3.getUrl(amazonConfig.getBucket(), keyName).toString();
+    }
+
+    public String generateUserKeyName(Uuid uuid) {
+        return amazonConfig.getUserPath() + '/' + uuid.getUuid(); // 멤버 프로필 사진
+    }
+
+    public String extractS3KeyFromUrl(String imageUrl) {
+        String bucketUrlPrefix = "https://" + amazonConfig.getBucket() + ".s3." + amazonConfig.getRegion() + ".amazonaws.com/";
+
+        if (imageUrl != null && imageUrl.startsWith(bucketUrlPrefix)) {
+            return imageUrl.substring(bucketUrlPrefix.length());
+        } else {
+            throw new IllegalArgumentException("S3 URL에서 key를 추출할 수 없습니다: " + imageUrl);
+        }
+    }
+
+    public void deleteFile(String keyName) {
+        amazonS3.deleteObject(amazonConfig.getBucket(), keyName);
+    }
+}

--- a/src/main/java/verbly/spring/global/common/code/ErrorStatus.java
+++ b/src/main/java/verbly/spring/global/common/code/ErrorStatus.java
@@ -29,7 +29,9 @@ public enum ErrorStatus implements BaseErrorCode {
     INVALID_JWT_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "TOKEN4001", "유효하지 않은 AccessToken입니다."),
     INVALID_JWT_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "TOKEN4002", "유효하지 않은 RefreshToken입니다."),
     INVALID_SOCIAL_TOKEN(HttpStatus.UNAUTHORIZED, "TOKEN4003", "유효하지 않은 SocialToken입니다."),
-    INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "PW4001", "잘못된 비밀번호입니다.");
+    INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "PW4001", "잘못된 비밀번호입니다."),
+
+    STATS_NOT_FOUND();
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/verbly/spring/global/common/code/ErrorStatus.java
+++ b/src/main/java/verbly/spring/global/common/code/ErrorStatus.java
@@ -23,6 +23,7 @@ public enum ErrorStatus implements BaseErrorCode {
     INVALID_IMAGE_TYPE(HttpStatus.BAD_REQUEST, "IMAGE4006", "이미지 형식의 파일만 업로드할 수 있습니다."),
     IMAGE_FILE_TOO_LARGE(HttpStatus.BAD_REQUEST, "IMAGE4007", "이미지 파일은 10MB 이하로 업로드해주세요."),
     NICKNAME_DUPLICATE(HttpStatus.BAD_REQUEST, "USER4008", "이미 사용 중인 닉네임입니다."),
+    ONBOARDING_ALREADY_COMPLETED(HttpStatus.BAD_REQUEST, "USER4009", "이미 온보딩이 완료된 유저입니다."),
 
     //jwt 토큰
     INVALID_JWT_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "TOKEN4001", "유효하지 않은 AccessToken입니다."),

--- a/src/main/java/verbly/spring/global/common/code/ErrorStatus.java
+++ b/src/main/java/verbly/spring/global/common/code/ErrorStatus.java
@@ -16,7 +16,7 @@ public enum ErrorStatus implements BaseErrorCode {
     ACCESS_DENIED(HttpStatus.FORBIDDEN, "COMMON4004", "권한이 없습니다."),
 
     // 유저 관련 에러
-    USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER4001", "사용자가 없습니다."),
+    USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER4001", "사용자가 존재하지 않습니다."),
     NICKNAME_NOT_EXIST(HttpStatus.BAD_REQUEST, "USER4002", "닉네임은 필수입니다."),
     ONBOARDING_NOT_COMPLETED(HttpStatus.BAD_REQUEST, "USER4003", "온보딩을 마치지 않았습니다."),
     SOCIALID_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER4005", "socialId가 없습니다."),

--- a/src/main/java/verbly/spring/global/common/code/ErrorStatus.java
+++ b/src/main/java/verbly/spring/global/common/code/ErrorStatus.java
@@ -31,7 +31,8 @@ public enum ErrorStatus implements BaseErrorCode {
     INVALID_SOCIAL_TOKEN(HttpStatus.UNAUTHORIZED, "TOKEN4003", "유효하지 않은 SocialToken입니다."),
     INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "PW4001", "잘못된 비밀번호입니다."),
 
-    STATS_NOT_FOUND();
+    // 통계 관련 에러
+    STATS_NOT_FOUND(HttpStatus.BAD_REQUEST, "STATS4001", "사용자 통계 정보가 존재하지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/verbly/spring/global/security/auth/CustomOAuth2User.java
+++ b/src/main/java/verbly/spring/global/security/auth/CustomOAuth2User.java
@@ -17,10 +17,12 @@ import java.util.Map;
 public class CustomOAuth2User implements OAuth2User, OidcUser {
     private final User user;
     private final Map<String, Object> attributes;
+    private final String provider; // kakao, google
 
-    public CustomOAuth2User(User user, Map<String, Object> attributes) {
+    public CustomOAuth2User(User user, Map<String, Object> attributes, String provider) {
         this.user = user;
         this.attributes = attributes;
+        this.provider = provider;
     }
 
     @Override

--- a/src/main/java/verbly/spring/global/security/oauth/handler/OAuth2FailureHandler.java
+++ b/src/main/java/verbly/spring/global/security/oauth/handler/OAuth2FailureHandler.java
@@ -18,13 +18,6 @@ public class OAuth2FailureHandler implements AuthenticationFailureHandler {
     public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
         log.error("❌ OAuth2 로그인 실패: {}", exception.getMessage());
 
-        // 리다이렉트 방식 (쿼리 파라미터에 에러 메시지 포함)
-//        String targetUrl = UriComponentsBuilder.fromUriString("https://verbly.com/login-fail")
-//                .queryParam("error", exception.getMessage())
-//                .build().toUriString();
-//
-//        response.sendRedirect(targetUrl);
-
         // JSON 응답 방식
         response.setContentType("application/json;charset=UTF-8");
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);

--- a/src/main/java/verbly/spring/global/security/oauth/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/verbly/spring/global/security/oauth/handler/OAuth2SuccessHandler.java
@@ -41,47 +41,9 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
         log.info("🔐 authentication.getPrincipal() 타입: {}", authentication.getPrincipal().getClass().getName());
 
         CustomOAuth2User oAuth2User = (CustomOAuth2User) authentication.getPrincipal();
-        String provider = oAuth2User.getProvider();
-        if ("google".equals(provider)) {
-
-            log.info("🔵 [GOOGLE] 로그인 성공");
-
-            Map<String, Object> attributes = oAuth2User.getAttributes();
-            log.info("🧩 attributes = {}", attributes);
-            if (oAuth2User.getIdToken() != null) { // idToken은 null일 수도 있음
-                log.info("🧩 idToken claims = {}", oAuth2User.getIdToken().getClaims());
-            } else {
-                log.info("⚠️ idToken is null (userinfo 기반 인증)");
-            }
-
-            log.info("👤 name: {}", attributes.get("name"));
-            log.info("📛 nickname(given_name): {}", attributes.get("given_name"));
-            log.info("🖼 profile image: {}", attributes.get("picture"));
-            log.info("📧 email: {}", attributes.get("email"));
-            log.info("🆔 sub: {}", attributes.get("sub"));
-        }
 
         User user = oAuth2User.getUser();
         log.info("🙋‍♂️ 로그인한 유저 ID: {}, 온보딩 상태: {}", user.getId(), user.getStatus());
-
-        Map<String, Object> attributes = oAuth2User.getAttributes();
-        if ("google".equals(provider)) {
-            String nickname = (String) attributes.get("name");
-            String email = (String) attributes.get("email");
-            String profileImageUrl = (String) attributes.get("picture");
-
-            user.setNickname(nickname);
-            user.setEmail(email);
-
-            if (user.getProfileImage() == null) {
-                user.setProfileImage(ProfileImage.builder()
-                        .user(user)
-                        .imageUrl(profileImageUrl)
-                        .build());
-            } else {
-                user.getProfileImage().setImageUrl(profileImageUrl);
-            }
-        }
 
         // JWT 발급
         String accessToken = jwtTokenProvider.generateAccessToken(authentication); // kakao_12345

--- a/src/main/java/verbly/spring/global/security/oauth/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/verbly/spring/global/security/oauth/handler/OAuth2SuccessHandler.java
@@ -12,6 +12,7 @@ import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import verbly.spring.domain.auth.dto.response.AuthResponseDTO;
+import verbly.spring.domain.user.entity.ProfileImage;
 import verbly.spring.domain.user.entity.User;
 import verbly.spring.domain.user.enums.UserStatus;
 import verbly.spring.global.common.code.SuccessStatus;
@@ -58,26 +59,29 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
             log.info("🖼 profile image: {}", attributes.get("picture"));
             log.info("📧 email: {}", attributes.get("email"));
             log.info("🆔 sub: {}", attributes.get("sub"));
-        } else if ("kakao".equals(provider)) {
-
-            log.info("🟡 [KAKAO] 로그인 성공");
-
-            Map<String, Object> attributes = oAuth2User.getAttributes();
-            log.info("🧩 attributes = {}", attributes);
-
-            Map<String, Object> kakaoAccount =
-                    (Map<String, Object>) attributes.get("kakao_account");
-            Map<String, Object> profile =
-                    (Map<String, Object>) kakaoAccount.get("profile");
-
-            log.info("👤 nickname: {}", profile.get("nickname"));
-            log.info("🖼 profile image: {}", profile.get("profile_image_url"));
-            log.info("📧 email: {}", kakaoAccount.get("email"));
-            log.info("🆔 kakao id: {}", attributes.get("id"));
         }
 
         User user = oAuth2User.getUser();
         log.info("🙋‍♂️ 로그인한 유저 ID: {}, 온보딩 상태: {}", user.getId(), user.getStatus());
+
+        Map<String, Object> attributes = oAuth2User.getAttributes();
+        if ("google".equals(provider)) {
+            String nickname = (String) attributes.get("name");
+            String email = (String) attributes.get("email");
+            String profileImageUrl = (String) attributes.get("picture");
+
+            user.setNickname(nickname);
+            user.setEmail(email);
+
+            if (user.getProfileImage() == null) {
+                user.setProfileImage(ProfileImage.builder()
+                        .user(user)
+                        .imageUrl(profileImageUrl)
+                        .build());
+            } else {
+                user.getProfileImage().setImageUrl(profileImageUrl);
+            }
+        }
 
         // JWT 발급
         String accessToken = jwtTokenProvider.generateAccessToken(authentication); // kakao_12345
@@ -91,6 +95,10 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
                 .userId(user.getId())
+                .provider(user.getProvider().toString())
+                .nickname(user.getNickname())
+                .profileImage(user.getProfileImage().getImageUrl())
+                .email(user.getEmail())
                 .status(user.getStatus().name())
                 .build();
 

--- a/src/main/java/verbly/spring/global/security/oauth/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/verbly/spring/global/security/oauth/handler/OAuth2SuccessHandler.java
@@ -8,6 +8,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import verbly.spring.domain.auth.dto.response.AuthResponseDTO;
 import verbly.spring.domain.user.entity.User;
@@ -21,6 +23,7 @@ import org.springframework.stereotype.Component;
 import java.io.IOException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.Map;
 
 @Slf4j
 @Component
@@ -37,6 +40,41 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
         log.info("🔐 authentication.getPrincipal() 타입: {}", authentication.getPrincipal().getClass().getName());
 
         CustomOAuth2User oAuth2User = (CustomOAuth2User) authentication.getPrincipal();
+        String provider = oAuth2User.getProvider();
+        if ("google".equals(provider)) {
+
+            log.info("🔵 [GOOGLE] 로그인 성공");
+
+            Map<String, Object> attributes = oAuth2User.getAttributes();
+            log.info("🧩 attributes = {}", attributes);
+            if (oAuth2User.getIdToken() != null) { // idToken은 null일 수도 있음
+                log.info("🧩 idToken claims = {}", oAuth2User.getIdToken().getClaims());
+            } else {
+                log.info("⚠️ idToken is null (userinfo 기반 인증)");
+            }
+
+            log.info("👤 name: {}", attributes.get("name"));
+            log.info("📛 nickname(given_name): {}", attributes.get("given_name"));
+            log.info("🖼 profile image: {}", attributes.get("picture"));
+            log.info("📧 email: {}", attributes.get("email"));
+            log.info("🆔 sub: {}", attributes.get("sub"));
+        } else if ("kakao".equals(provider)) {
+
+            log.info("🟡 [KAKAO] 로그인 성공");
+
+            Map<String, Object> attributes = oAuth2User.getAttributes();
+            log.info("🧩 attributes = {}", attributes);
+
+            Map<String, Object> kakaoAccount =
+                    (Map<String, Object>) attributes.get("kakao_account");
+            Map<String, Object> profile =
+                    (Map<String, Object>) kakaoAccount.get("profile");
+
+            log.info("👤 nickname: {}", profile.get("nickname"));
+            log.info("🖼 profile image: {}", profile.get("profile_image_url"));
+            log.info("📧 email: {}", kakaoAccount.get("email"));
+            log.info("🆔 kakao id: {}", attributes.get("id"));
+        }
 
         User user = oAuth2User.getUser();
         log.info("🙋‍♂️ 로그인한 유저 ID: {}, 온보딩 상태: {}", user.getId(), user.getStatus());

--- a/src/main/java/verbly/spring/global/security/oauth/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/verbly/spring/global/security/oauth/handler/OAuth2SuccessHandler.java
@@ -85,18 +85,6 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
         log.info("🔑 AccessToken: {}, RefreshToken: {}", accessToken, refreshToken);
 
-        /*
-        // 리다이렉트 + 쿼리파라미터 방식: 프론트엔드가 토큰 읽을 수 있도록 전달 -> url에 토큰 노출
-        String redirectUri = (user.getStatus() == UserStatus.ONBOARDING)
-                ? "https://verbly.com/onboarding"
-                : "https://verbly.com/home";
-
-        redirectUri += "?accessToken=" + URLEncoder.encode(accessToken, StandardCharsets.UTF_8)
-                + "&refreshToken=" + URLEncoder.encode(refreshToken, StandardCharsets.UTF_8);
-
-        response.sendRedirect(redirectUri);
-        */
-
         /**/
         // JSON 응답 방식 (SPA 등 API 호출용)
         AuthResponseDTO.LoginResultDTO result = AuthResponseDTO.LoginResultDTO.builder()

--- a/src/main/java/verbly/spring/global/security/oauth/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/verbly/spring/global/security/oauth/handler/OAuth2SuccessHandler.java
@@ -87,6 +87,10 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
         addCookie(response, "accessToken", accessToken, true, 60 * 60 * 4); // 4시간
         addCookie(response, "refreshToken", refreshToken, true, 60 * 60 * 24 * 7); // 7일
         addCookie(response, "userId", String.valueOf(user.getId()), true, 60 * 60 * 4);
+        addCookie(response, "provider", user.getProvider().toString(), false, 60 * 60 * 4);
+        addCookie(response, "nickname", user.getNickname(), false, 60 * 60 * 4);
+        addCookie(response, "profileImage", user.getProfileImage().getImageUrl(), false, 60 * 60 * 4);
+        addCookie(response, "email", user.getEmail(), false, 60 * 60 * 4);
         addCookie(response, "userStatus", String.valueOf(user.getStatus()), false, 60 * 60 * 4);
 
         // 2. 상태 정보: HttpOnly = false (JS에서 읽게)

--- a/src/main/java/verbly/spring/global/security/oauth/service/CustomOAuth2UserService.java
+++ b/src/main/java/verbly/spring/global/security/oauth/service/CustomOAuth2UserService.java
@@ -45,7 +45,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService { // Defau
         User user = userRepository.findBySocialId(checkSocialId)
                 .orElseGet(() -> saveNewUser(userInfo, provider)); // 3. 회원 조회 or 신규 회원 등록
 
-        return new CustomOAuth2User(user, oAuth2User.getAttributes()); // 4. 반환할 OAuth2User 구현체 (권한 부여용)
+        return new CustomOAuth2User(user, oAuth2User.getAttributes(), provider); // 4. 반환할 OAuth2User 구현체 (권한 부여용)
 //        return super.loadUser(userRequest);
     }
 

--- a/src/main/java/verbly/spring/global/security/oauth/service/CustomOAuth2UserService.java
+++ b/src/main/java/verbly/spring/global/security/oauth/service/CustomOAuth2UserService.java
@@ -12,6 +12,7 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import verbly.spring.domain.user.entity.ProfileImage;
+import verbly.spring.domain.user.entity.Stats;
 import verbly.spring.domain.user.entity.User;
 import verbly.spring.domain.user.enums.AuthProvider;
 import verbly.spring.domain.user.enums.UserStatus;
@@ -94,6 +95,15 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService { // Defau
                 .user(user)
                 .imageUrl(profileImageUrl)
                 .build());
+
+        Stats stats = Stats.builder()
+                .user(user)
+                .userId(user.getId()) // 아직 DB 저장 전이라 null일 수 있음, save 후 update 가능
+                .point(100) // 가입 보너스 100P
+                .streakDays(0)
+                .lastActiveDate(null)
+                .build();
+        user.setStats(stats);
 
         return userRepository.save(user);
     }

--- a/src/main/java/verbly/spring/global/security/oauth/service/CustomOAuth2UserService.java
+++ b/src/main/java/verbly/spring/global/security/oauth/service/CustomOAuth2UserService.java
@@ -2,9 +2,6 @@ package verbly.spring.global.security.oauth.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
@@ -12,7 +9,7 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import verbly.spring.domain.user.entity.ProfileImage;
-import verbly.spring.domain.user.entity.Stats;
+import verbly.spring.domain.stats.entity.Stats;
 import verbly.spring.domain.user.entity.User;
 import verbly.spring.domain.user.enums.AuthProvider;
 import verbly.spring.domain.user.enums.UserStatus;

--- a/src/main/java/verbly/spring/global/security/oauth/service/CustomOAuth2UserService.java
+++ b/src/main/java/verbly/spring/global/security/oauth/service/CustomOAuth2UserService.java
@@ -8,6 +8,7 @@ import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import verbly.spring.domain.user.entity.NotificationSettings;
 import verbly.spring.domain.user.entity.ProfileImage;
 import verbly.spring.domain.stats.entity.Stats;
 import verbly.spring.domain.user.entity.User;
@@ -101,6 +102,9 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService { // Defau
                 .lastActiveDate(null)
                 .build();
         user.setStats(stats);
+
+        NotificationSettings notificationSettings = NotificationSettings.defaultOf(user);
+        user.setNotificationSettings(notificationSettings);
 
         return userRepository.save(user);
     }

--- a/src/main/java/verbly/spring/global/security/oauth/service/CustomOAuth2UserService.java
+++ b/src/main/java/verbly/spring/global/security/oauth/service/CustomOAuth2UserService.java
@@ -10,6 +10,8 @@ import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import verbly.spring.domain.user.entity.ProfileImage;
 import verbly.spring.domain.user.entity.User;
 import verbly.spring.domain.user.enums.AuthProvider;
 import verbly.spring.domain.user.enums.UserStatus;
@@ -20,6 +22,10 @@ import verbly.spring.global.security.auth.CustomOAuth2User;
 import verbly.spring.global.security.oauth.userinfo.OAuth2UserInfo;
 import verbly.spring.global.security.oauth.userinfo.OAuth2UserInfoFactory;
 
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -27,6 +33,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService { // Defau
     private final UserRepository userRepository;
 
     @Override
+    @Transactional
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
 
         OAuth2User oAuth2User = super.loadUser(userRequest); // 1. 소셜 API에서 사용자 정보 가져오기
@@ -45,18 +52,49 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService { // Defau
         User user = userRepository.findBySocialId(checkSocialId)
                 .orElseGet(() -> saveNewUser(userInfo, provider)); // 3. 회원 조회 or 신규 회원 등록
 
+        log.info("🟡 [KAKAO] 로그인 성공");
+
+        Map<String, Object> attributes = oAuth2User.getAttributes();
+        log.info("🧩 attributes = {}", attributes);
+
+        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+        Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
+
+        log.info("👤 nickname: {}", profile.get("nickname"));
+        log.info("🖼 profile image: {}", profile.get("profile_image_url"));
+        log.info("📧 email: {}", kakaoAccount.get("email"));
+        log.info("🆔 kakao id: {}", attributes.get("id"));
+
         return new CustomOAuth2User(user, oAuth2User.getAttributes(), provider); // 4. 반환할 OAuth2User 구현체 (권한 부여용)
 //        return super.loadUser(userRequest);
     }
 
     private User saveNewUser(OAuth2UserInfo userInfo, String provider) {
         log.info("🆕 {} 신규 유저로 저장 시도", provider);
+
+        Map<String, Object> kakaoAccount = (Map<String, Object>) userInfo.getAttributes().get("kakao_account");
+        //Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
+        Map<String, Object> profile = (Map<String, Object>) Optional.ofNullable(kakaoAccount.get("profile"))
+                .orElse(Collections.emptyMap());
         String socialId = provider.toLowerCase() + "_" + userInfo.getSocialId(); // kakao_12345
+
         User user = User.builder()
                 .socialId(socialId)
                 .provider(AuthProvider.from(provider))
+                .nickname((String) profile.get("nickname"))
+                .email((String) kakaoAccount.get("email"))
                 .status(UserStatus.NEED_ONBOARDING)
                 .build();
+
+        //String profileImageUrl = (String) profile.get("profile_image_url");
+        String profileImageUrl = (String) Optional.ofNullable(profile.get("profile_image_url"))
+                .orElse("default_profile_url");
+
+        user.setProfileImage(ProfileImage.builder()
+                .user(user)
+                .imageUrl(profileImageUrl)
+                .build());
+
         return userRepository.save(user);
     }
 }

--- a/src/main/java/verbly/spring/global/security/oauth/service/CustomOidcUserService.java
+++ b/src/main/java/verbly/spring/global/security/oauth/service/CustomOidcUserService.java
@@ -42,7 +42,7 @@ public class CustomOidcUserService extends OidcUserService {
         User user = userRepository.findBySocialId(checkSocialId)
                 .orElseGet(() -> saveNewUser(userInfo, provider)); // 3. 회원 조회 or 신규 회원 등록
 
-        return new CustomOAuth2User(user, oidcUser.getAttributes()); // 4. 반환할 OAuth2User 구현체 (권한 부여용)
+        return new CustomOAuth2User(user, oidcUser.getAttributes(), provider); // 4. 반환할 OAuth2User 구현체 (권한 부여용)
     }
 
     private User saveNewUser(OAuth2UserInfo userInfo, String provider) {

--- a/src/main/java/verbly/spring/global/security/oauth/service/CustomOidcUserService.java
+++ b/src/main/java/verbly/spring/global/security/oauth/service/CustomOidcUserService.java
@@ -9,6 +9,7 @@ import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import verbly.spring.domain.user.entity.ProfileImage;
+import verbly.spring.domain.user.entity.Stats;
 import verbly.spring.domain.user.entity.User;
 import verbly.spring.domain.user.enums.AuthProvider;
 import verbly.spring.domain.user.enums.UserStatus;
@@ -94,6 +95,15 @@ public class CustomOidcUserService extends OidcUserService {
                 .user(user)
                 .imageUrl(profileImageUrl)
                 .build());
+
+        Stats stats = Stats.builder()
+                .user(user)
+                .userId(user.getId()) // 아직 DB 저장 전이라 null일 수 있음, save 후 update 가능
+                .point(100) // 가입 보너스 100P
+                .streakDays(0)
+                .lastActiveDate(null)
+                .build();
+        user.setStats(stats);
 
         return userRepository.save(user);
     }

--- a/src/main/java/verbly/spring/global/security/oauth/service/CustomOidcUserService.java
+++ b/src/main/java/verbly/spring/global/security/oauth/service/CustomOidcUserService.java
@@ -8,6 +8,7 @@ import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import verbly.spring.domain.user.entity.NotificationSettings;
 import verbly.spring.domain.user.entity.ProfileImage;
 import verbly.spring.domain.stats.entity.Stats;
 import verbly.spring.domain.user.entity.User;
@@ -104,6 +105,9 @@ public class CustomOidcUserService extends OidcUserService {
                 .lastActiveDate(null)
                 .build();
         user.setStats(stats);
+
+        NotificationSettings notificationSettings = NotificationSettings.defaultOf(user);
+        user.setNotificationSettings(notificationSettings);
 
         return userRepository.save(user);
     }

--- a/src/main/java/verbly/spring/global/security/oauth/service/CustomOidcUserService.java
+++ b/src/main/java/verbly/spring/global/security/oauth/service/CustomOidcUserService.java
@@ -7,6 +7,7 @@ import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserService;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import verbly.spring.domain.user.entity.ProfileImage;
 import verbly.spring.domain.user.entity.User;
 import verbly.spring.domain.user.enums.AuthProvider;
@@ -28,6 +29,7 @@ public class CustomOidcUserService extends OidcUserService {
     private final UserRepository userRepository;
 
     @Override
+    @Transactional
     public OidcUser loadUser(OidcUserRequest userRequest) throws OAuth2AuthenticationException {
 
         OidcUser oidcUser = super.loadUser(userRequest); // 1. 소셜 API에서 사용자 정보 가져오기

--- a/src/main/java/verbly/spring/global/security/oauth/service/CustomOidcUserService.java
+++ b/src/main/java/verbly/spring/global/security/oauth/service/CustomOidcUserService.java
@@ -9,7 +9,7 @@ import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import verbly.spring.domain.user.entity.ProfileImage;
-import verbly.spring.domain.user.entity.Stats;
+import verbly.spring.domain.stats.entity.Stats;
 import verbly.spring.domain.user.entity.User;
 import verbly.spring.domain.user.enums.AuthProvider;
 import verbly.spring.domain.user.enums.UserStatus;

--- a/src/main/java/verbly/spring/global/security/oauth/service/CustomOidcUserService.java
+++ b/src/main/java/verbly/spring/global/security/oauth/service/CustomOidcUserService.java
@@ -7,6 +7,7 @@ import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserService;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.stereotype.Service;
+import verbly.spring.domain.user.entity.ProfileImage;
 import verbly.spring.domain.user.entity.User;
 import verbly.spring.domain.user.enums.AuthProvider;
 import verbly.spring.domain.user.enums.UserStatus;
@@ -16,6 +17,9 @@ import verbly.spring.global.common.code.ErrorStatus;
 import verbly.spring.global.security.auth.CustomOAuth2User;
 import verbly.spring.global.security.oauth.userinfo.OAuth2UserInfo;
 import verbly.spring.global.security.oauth.userinfo.OAuth2UserInfoFactory;
+
+import java.util.Map;
+import java.util.Optional;
 
 @Slf4j
 @Service
@@ -42,17 +46,53 @@ public class CustomOidcUserService extends OidcUserService {
         User user = userRepository.findBySocialId(checkSocialId)
                 .orElseGet(() -> saveNewUser(userInfo, provider)); // 3. 회원 조회 or 신규 회원 등록
 
+        log.info("🔵 [GOOGLE] 로그인 성공");
+
+        Map<String, Object> attributes = oidcUser.getAttributes();
+        log.info("🧩 attributes = {}", attributes);
+        if (oidcUser.getIdToken() != null) { // idToken은 null일 수도 있음
+            log.info("🧩 idToken claims = {}", oidcUser.getIdToken().getClaims());
+        } else {
+            log.info("⚠️ idToken is null (userinfo 기반 인증)");
+        }
+
+        log.info("👤 name: {}", attributes.get("name"));
+        log.info("📛 nickname(given_name): {}", attributes.get("given_name"));
+        log.info("🖼 profile image: {}", attributes.get("picture"));
+        log.info("📧 email: {}", attributes.get("email"));
+        log.info("🆔 sub: {}", attributes.get("sub"));
+
         return new CustomOAuth2User(user, oidcUser.getAttributes(), provider); // 4. 반환할 OAuth2User 구현체 (권한 부여용)
     }
 
     private User saveNewUser(OAuth2UserInfo userInfo, String provider) {
         log.info("🆕 {} 신규 유저로 저장 시도", provider);
+
+        String nickname = Optional.ofNullable(userInfo.getAttributes().get("given_name"))
+                .map(Object::toString)
+                .orElse("익명");
+        String email = Optional.ofNullable(userInfo.getAttributes().get("email"))
+                .map(Object::toString)
+                .orElse("noemail@example.com");
         String socialId = provider.toLowerCase() + "_" + userInfo.getSocialId();
+
         User user = User.builder()
                 .socialId(socialId)
                 .provider(AuthProvider.from(provider))
+                .nickname(nickname)
+                .email(email)
                 .status(UserStatus.NEED_ONBOARDING)
                 .build();
+
+        String profileImageUrl = Optional.ofNullable(userInfo.getAttributes().get("picture"))
+                .map(Object::toString)
+                .orElse("default_profile_url");
+
+        user.setProfileImage(ProfileImage.builder()
+                .user(user)
+                .imageUrl(profileImageUrl)
+                .build());
+
         return userRepository.save(user);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   application:
     name: Verbly
   profiles:
-    active: local # dev, prod(배포 때 Amazon Config 같이 동작하도록 수정)
+    active: prod # local, dev, prod(배포 때 Amazon Config 같이 동작하도록 수정)
   datasource:
     url: ${DB_URL}
     username: ${DB_USERNAME}
@@ -28,7 +28,7 @@ spring:
         format_sql: true
         use_sql_comments: true
         hbm2ddl:
-          auto: create # update #validate
+          auto: update #create #update #validate
         default_batch_fetch_size: 1000
   data:
     web:
@@ -79,9 +79,26 @@ spring:
       # false (기본값): 파일 파싱이 컨트롤러 진입 전에 이뤄짐
       # true: 파일 파싱을 컨트롤러 파라미터 바인딩 시점으로 미룸
       resolve-lazily: false
+server:
+  forward-headers-strategy: framework
+  tomcat:
+    max-swallow-size: 200MB
 jwt:
   token:
     secretKey: ${JWT_SECRETKEY}
     expiration: # (만료) 시간 설정은 ms단위
       access: 14400000 # 4시간(보통 1시간~4시간 단위를 많이 채택)
       refresh: 604800000 # 7일
+cloud:
+  aws:
+    s3:
+      bucket: verbly-bucket
+      path:
+        user: profile
+    region:
+      static: ap-northeast-2
+    stack:
+      auto: false
+    credentials:
+      accessKey: ${AWS_ACCESS_KEY}
+      secretKey: ${AWS_SECRET_KEY}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -49,12 +49,28 @@ spring:
               - profile_image
               - account_email
             client-name: Kakao
+          google:
+            client-authentication-method: client_secret_post
+            client-id: ${GOOGLE_CLIENT_ID}
+            client-secret: ${GOOGLE_SECRET}
+            redirect-uri: ${GOOGLE_REDIRECT_URL}
+            authorization-grant-type: authorization_code
+            scope:
+              - openid
+              - profile
+              - email
+            client-name: Google
         provider:
           kakao:
             authorization-uri: https://kauth.kakao.com/oauth/authorize
             token-uri: https://kauth.kakao.com/oauth/token
             user-info-uri: https://kapi.kakao.com/v2/user/me
             user-name-attribute: id
+          google:
+            authorization-uri: https://accounts.google.com/o/oauth2/v2/auth
+            token-uri: https://oauth2.googleapis.com/token
+            user-info-uri: https://www.googleapis.com/oauth2/v3/userinfo
+            user-name-attribute: sub
   servlet:
     multipart:
       maxFileSize: 10MB # 파일 하나의 최대 크기


### PR DESCRIPTION
## #️⃣ 기능 설명
> 상동

## 🛠️ 작업 상세 내용
- [x] 구글 소셜로그인 구현
- [x] 회원가입 성공 시 일회성으로 100p 지급
- [x] 회원가입 성공 시 알람 세팅(이메일, 푸쉬, 커렉션) true값으로
- [x] auth(토큰 재발급, 로그아웃) 관련 기능 개발 완료
- [x] 로컬 스웨거 확인
- [x] 토큰 재발급 테스트 위해 스웨거에서 json으로 보이도록 수정
- [x] 회원가입 성공 시 알람 세팅(이메일, 푸쉬, 커렉션) true값으로

## 📸 스크린샷 (선택)
구글 소셜로그인 구현
<img width="907" height="557" alt="image" src="https://github.com/user-attachments/assets/8183db59-835b-46e9-a257-1d333f9a84fc" />
<img width="893" height="661" alt="image" src="https://github.com/user-attachments/assets/1e004429-a1dd-47db-a728-bf4510840e2d" />
카카오와 구글 프로필 저장
<img width="535" height="397" alt="image" src="https://github.com/user-attachments/assets/ce803fac-4d13-40fb-a490-5d040c0cc5ce" />
<img width="752" height="789" alt="image" src="https://github.com/user-attachments/assets/969b5b0b-1e89-4c13-bfae-f5d8cc5ed17d" />
<img width="374" height="333" alt="image" src="https://github.com/user-attachments/assets/d42e8404-e34e-4b23-8b63-30f42b7e58a9" />
<img width="501" height="656" alt="image" src="https://github.com/user-attachments/assets/22ecaa0a-c4ec-4ede-a3e1-b0ae3458a300" />

로컬 스웨거 완료
<img width="842" height="960" alt="image" src="https://github.com/user-attachments/assets/31ae46ff-372a-4e51-a94a-d2cdb0087b84" />

## 💬 기타(공유사항 to 리뷰어)
환경변수 넣고 run한 후, 각 소셜로그인 아래에서 확인 가능
kakao
http://localhost:8080/oauth2/authorization/kakao
google
http://localhost:8080/oauth2/authorization/google

datagrip으로
- stats테이블의 point에 100 확인 가능
- 프로필 이미지 링크 복붙하면 이미지 확인 가능

아래에서 다른 API 확인 가능
http://localhost:8080/swagger-ui/index.html
(온보딩은 수정할게 있어서 다른거 위주로 테스트해주세요! 온보딩 제외 아래 나머지는 문제 없습니다.)

DELETE
 회원 탈퇴 API - JWT AccessToken 인증 필요
PATCH
 마이페이지 회원 정보 수정 API - JWT AccessToken 인증 필요
GET
 회원 정보 조회 API - JWT AccessToken 인증 필요

POST 토큰 재발급 API - JWT RefreshToken 인증 필요
POST
 회원 로그아웃 API - JWT AccessToken 인증 필요

향후 개발 사항
- 현재는 로컬 단계이므로 json으로 보이게 했지만 도메인 배포 후에는 쿠키로 내려줄 예정(쿠키로 내려줄 코드도 미리 짜놨습니다.)
- 소셜로그인 지금은 json으로 보이게 해놨지만 쿠키로 내려줄 예정
- 토큰 재발급 상동
- 백엔드 배포 26일 예정
- 회원가입 시 100p지급, 알람 세팅 등의 코드는 분리해서 리팩토링 예정
- 유저 정보 info 응답은 다른 팀원 코드 추가 시 수정 예정

유저 기능 먼저 dev에 합치고 @yunnij 님 피알 확인 후 머지할게요!

---
@keypang 홈 조회 API 하나 부탁드릴게요! 예를 들면 아래처럼
```java
@GetMapping("/home")
public HomeResponse getHome(@AuthenticationPrincipal User user) {
    statsService.markAttendanceIfNeeded(user);
    return homeService.getHomeData(user);
}

// 그리고 서비스에서
@Transactional
public void markAttendanceIfNeeded(User user) {
    Stats stats = user.getStats();
    stats.markAttendance(user.getTimezone()); // <-- 이게 제가 Stats에 구현한 메소드인데 호출 한 번 부탁드릴게요!
}
```
홈 화면 접속 기준으로 출석일을 체크한다고 합니다! 이렇게 하면 홈에 들어올 때마다 호출은 되지만 markAttendance() 내부에서 같은 날이면 return해서 연속 여부 계산하기 때문에 중복 호출 문제 없이 기능할 것 같습니다.

프론트는 홈 화면 API 호출하기만 하면 출석 계산은 서버가 책임 가져갈 수 있습니다.