### PR TITLE
✨[Feat] 유저 정보 응답 api에 부족한 응답 추가

### DIFF
--- a/src/main/java/verbly/spring/domain/correction/repository/CorrectionFeedbackRepository.java
+++ b/src/main/java/verbly/spring/domain/correction/repository/CorrectionFeedbackRepository.java
@@ -5,4 +5,5 @@ import verbly.spring.domain.correction.entity.CorrectionFeedback;
 
 public interface CorrectionFeedbackRepository extends JpaRepository<CorrectionFeedback, Long> {
     void deleteAllByCorrectionId(Long correctionId);
+    long countByCorrector_Id(Long correctorId);
 }

--- a/src/main/java/verbly/spring/domain/correction/repository/CorrectionRepository.java
+++ b/src/main/java/verbly/spring/domain/correction/repository/CorrectionRepository.java
@@ -8,4 +8,5 @@ import java.util.Optional;
 public interface CorrectionRepository extends JpaRepository<Correction, Long> {
     Optional<Correction> findByPostId(Long postId);
     boolean existsByPostId(Long postId);
+    long countByPost_Author_Id(Long authorId);
 }

--- a/src/main/java/verbly/spring/domain/post/repository/PostRepository.java
+++ b/src/main/java/verbly/spring/domain/post/repository/PostRepository.java
@@ -8,5 +8,6 @@ import java.util.List;
 public interface PostRepository extends JpaRepository<Post, Long> {
 
     List<Post> findAllByAuthorIdOrderByIdDesc(Long authorId);
+    long countByAuthor_Id(Long userId);
 
 }

--- a/src/main/java/verbly/spring/domain/stats/entity/Stats.java
+++ b/src/main/java/verbly/spring/domain/stats/entity/Stats.java
@@ -27,11 +27,11 @@ public class Stats {
     @JoinColumn(name = "user_id")
     private User user;
 
-    // total_posts(전체 글 개수), correction_received(도움받은 글 개수), correction_given(도움 준 글 개수)는 단순 숫자만 사용하게 될 예정
+    // total_posts(전체 글 개수), correction_given(도움 준 글 개수), correction_received(도움받은 글 개수)는 단순 숫자만 사용하게 될 예정
     // -> 조회 시에만 서비스에서 계산되는 방식
     // total_posts -> post 테이블의 로그인한 user_id 수
-    // correction_received -> feedback 테이블의 user_id 수
     // correction_given -> correction테이블의 user_id 수
+    // correction_received -> feedback 테이블의 user_id 수
 
     // 아래는 행동 시 계산
     private long point; // 레벨 시스템 기준 (7레벨까지)

--- a/src/main/java/verbly/spring/domain/user/converter/UserConverter.java
+++ b/src/main/java/verbly/spring/domain/user/converter/UserConverter.java
@@ -4,6 +4,8 @@ import verbly.spring.domain.user.dto.response.UserResponseDTO;
 import verbly.spring.domain.user.entity.ProfileImage;
 import verbly.spring.domain.user.entity.User;
 
+import java.util.Optional;
+
 public class UserConverter {
     public static ProfileImage toProfileImage(String imageUrl, User user) {
         return ProfileImage.builder()
@@ -13,10 +15,14 @@ public class UserConverter {
     }
 
     public static UserResponseDTO.OnboardingResultDTO toOnboardingResponseDTO(User user) {
+        String profileImageUrl = Optional.ofNullable(user.getProfileImage())
+                .map(ProfileImage::getImageUrl)
+                .orElse("default_profile_url");
+
         return UserResponseDTO.OnboardingResultDTO.builder()
                 .userId(user.getId())
                 .nickname(user.getNickname())
-                .profileImage(user.getProfileImage().getImageUrl())
+                .profileImage(profileImageUrl)
                 .learningLang(user.getLearningLang())
                 .nativeLang(user.getNativeLang())
                 .status(user.getStatus().name())
@@ -24,12 +30,17 @@ public class UserConverter {
     }
 
     public static UserResponseDTO.UserInfoDTO toUserInfoDTO(User user, long totalPosts) {
+        String profileImageUrl = Optional.ofNullable(user.getProfileImage())
+                .map(ProfileImage::getImageUrl)
+                .orElse("default_profile_url");
+
+
         return UserResponseDTO.UserInfoDTO.builder()
                 .userId(user.getId())
                 .learningLang(user.getLearningLang())
                 .nativeLang(user.getNativeLang())
                 .nickname(user.getNickname())
-                .profileImage(user.getProfileImage().getImageUrl())
+                .profileImage(profileImageUrl)
                 .bio(user.getBio())
                 .email(user.getEmail())
                 .phoneNumber(user.getPhoneNumber())

--- a/src/main/java/verbly/spring/domain/user/converter/UserConverter.java
+++ b/src/main/java/verbly/spring/domain/user/converter/UserConverter.java
@@ -23,7 +23,7 @@ public class UserConverter {
                 .build();
     }
 
-    public static UserResponseDTO.UserInfoDTO toUserInfoDTO(User user) {
+    public static UserResponseDTO.UserInfoDTO toUserInfoDTO(User user, long totalPosts) {
         return UserResponseDTO.UserInfoDTO.builder()
                 .userId(user.getId())
                 .learningLang(user.getLearningLang())
@@ -37,7 +37,7 @@ public class UserConverter {
                 .point(user.getStats().getPoint())
                 .level(user.getStats().getLevel().getValue())
 //                .followCount(user.getFollowCount())
-//                .postCount(postCount)
+                .totalPosts(totalPosts)
 //                .correctionsGiven(correctionsGiven)
 //                .correctionsReceived(correctionsReceived)
                 .status(user.getStatus().name())

--- a/src/main/java/verbly/spring/domain/user/converter/UserConverter.java
+++ b/src/main/java/verbly/spring/domain/user/converter/UserConverter.java
@@ -29,11 +29,10 @@ public class UserConverter {
                 .build();
     }
 
-    public static UserResponseDTO.UserInfoDTO toUserInfoDTO(User user, long totalPosts) {
+    public static UserResponseDTO.UserInfoDTO toUserInfoDTO(User user, long totalPosts, long correctionsGiven, long correctionsReceived) {
         String profileImageUrl = Optional.ofNullable(user.getProfileImage())
                 .map(ProfileImage::getImageUrl)
                 .orElse("default_profile_url");
-
 
         return UserResponseDTO.UserInfoDTO.builder()
                 .userId(user.getId())
@@ -49,8 +48,8 @@ public class UserConverter {
                 .level(user.getStats().getLevel().getValue())
 //                .followCount(user.getFollowCount())
                 .totalPosts(totalPosts)
-//                .correctionsGiven(correctionsGiven)
-//                .correctionsReceived(correctionsReceived)
+                .correctionsGiven(correctionsGiven)
+                .correctionsReceived(correctionsReceived)
                 .status(user.getStatus().name())
                 .build();
     }

--- a/src/main/java/verbly/spring/domain/user/dto/response/UserResponseDTO.java
+++ b/src/main/java/verbly/spring/domain/user/dto/response/UserResponseDTO.java
@@ -38,7 +38,7 @@ public class UserResponseDTO {
         private int level;
 
 //        private long followCount;
-//        private long totalCount;
+        private long totalPosts;
 //        private long correctionsGiven; // 외국인에게만 뜨는 도움 준 수
 //        private long correctionsReceived; // 한국인에게만 뜨는 도움 받은 글
 

--- a/src/main/java/verbly/spring/domain/user/dto/response/UserResponseDTO.java
+++ b/src/main/java/verbly/spring/domain/user/dto/response/UserResponseDTO.java
@@ -39,8 +39,8 @@ public class UserResponseDTO {
 
 //        private long followCount;
         private long totalPosts;
-//        private long correctionsGiven; // 외국인에게만 뜨는 도움 준 수
-//        private long correctionsReceived; // 한국인에게만 뜨는 도움 받은 글
+        private long correctionsGiven; // 외국인에게만 뜨는 도움 준 수
+        private long correctionsReceived; // 한국인에게만 뜨는 도움 받은 글
 
         private String status;
     }

--- a/src/main/java/verbly/spring/domain/user/service/UserQueryServiceImpl.java
+++ b/src/main/java/verbly/spring/domain/user/service/UserQueryServiceImpl.java
@@ -3,6 +3,8 @@ package verbly.spring.domain.user.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import verbly.spring.domain.correction.repository.CorrectionFeedbackRepository;
+import verbly.spring.domain.correction.repository.CorrectionRepository;
 import verbly.spring.domain.post.repository.PostRepository;
 import verbly.spring.domain.user.converter.UserConverter;
 import verbly.spring.domain.user.dto.response.UserResponseDTO;
@@ -18,6 +20,8 @@ import verbly.spring.global.security.jwt.JwtTokenProvider;
 public class UserQueryServiceImpl implements UserQueryService {
     private final UserRepository userRepository;
     private final PostRepository postRepository;
+    private final CorrectionRepository correctionRepository;
+    private final CorrectionFeedbackRepository correctionFeedbackRepository;
     private final JwtTokenProvider jwtTokenProvider;
     private final ProfileValidator profileValidator;
 
@@ -31,9 +35,9 @@ public class UserQueryServiceImpl implements UserQueryService {
                 .orElseThrow(()-> new UserHandler(ErrorStatus.USER_NOT_FOUND));
 
         long totalPosts = postRepository.countByAuthor_Id(user.getId());
-//        long correctionsGiven = correctionRepository.countByUserId(user.getId());
-//        long correctionsReceived = feedbackRepository.countByUserId(user.getId());
+        long correctionsGiven = correctionFeedbackRepository.countByCorrector_Id(user.getId());
+        long correctionsReceived = correctionRepository.countByPost_Author_Id(user.getId());
 
-        return UserConverter.toUserInfoDTO(user, totalPosts);//, correctionsGiven, correctionsReceived); // 정보 조회에 성공하면, 우리가 정의한 Response DTO인 UserInfoDTO 로 반환
+        return UserConverter.toUserInfoDTO(user, totalPosts, correctionsGiven, correctionsReceived); // 정보 조회에 성공하면, 우리가 정의한 Response DTO인 UserInfoDTO 로 반환
     }
 }

--- a/src/main/java/verbly/spring/domain/user/service/UserQueryServiceImpl.java
+++ b/src/main/java/verbly/spring/domain/user/service/UserQueryServiceImpl.java
@@ -3,6 +3,7 @@ package verbly.spring.domain.user.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import verbly.spring.domain.post.repository.PostRepository;
 import verbly.spring.domain.user.converter.UserConverter;
 import verbly.spring.domain.user.dto.response.UserResponseDTO;
 import verbly.spring.domain.user.entity.User;
@@ -16,6 +17,7 @@ import verbly.spring.global.security.jwt.JwtTokenProvider;
 @RequiredArgsConstructor
 public class UserQueryServiceImpl implements UserQueryService {
     private final UserRepository userRepository;
+    private final PostRepository postRepository;
     private final JwtTokenProvider jwtTokenProvider;
     private final ProfileValidator profileValidator;
 
@@ -28,10 +30,10 @@ public class UserQueryServiceImpl implements UserQueryService {
         User user = userRepository.findById(userId) // UserRepository 로부터 사용자 정보를 조회
                 .orElseThrow(()-> new UserHandler(ErrorStatus.USER_NOT_FOUND));
 
-//        long totalCount = postRepository.countByUserId(user.getId());
+        long totalPosts = postRepository.countByAuthor_Id(user.getId());
 //        long correctionsGiven = correctionRepository.countByUserId(user.getId());
 //        long correctionsReceived = feedbackRepository.countByUserId(user.getId());
 
-        return UserConverter.toUserInfoDTO(user);//, totalCount, correctionsGiven, correctionsReceived); // 정보 조회에 성공하면, 우리가 정의한 Response DTO인 UserInfoDTO 로 반환
+        return UserConverter.toUserInfoDTO(user, totalPosts);//, correctionsGiven, correctionsReceived); // 정보 조회에 성공하면, 우리가 정의한 Response DTO인 UserInfoDTO 로 반환
     }
 }

--- a/src/main/java/verbly/spring/global/security/oauth/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/verbly/spring/global/security/oauth/handler/OAuth2SuccessHandler.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
+import java.util.Optional;
 
 @Slf4j
 @Component
@@ -51,6 +52,12 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
         log.info("🔑 AccessToken: {}, RefreshToken: {}", accessToken, refreshToken);
 
+        String nickname = Optional.ofNullable(user.getNickname()).orElse("");
+        String profileImageUrl = Optional.ofNullable(user.getProfileImage())
+                .map(ProfileImage::getImageUrl)
+                .orElse("default_profile_url");
+        String email = Optional.ofNullable(user.getEmail()).orElse("");
+
         /**/
         // JSON 응답 방식 (SPA 등 API 호출용)
         AuthResponseDTO.LoginResultDTO result = AuthResponseDTO.LoginResultDTO.builder()
@@ -58,9 +65,9 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
                 .refreshToken(refreshToken)
                 .userId(user.getId())
                 .provider(user.getProvider().toString())
-                .nickname(user.getNickname())
-                .profileImage(user.getProfileImage().getImageUrl())
-                .email(user.getEmail())
+                .nickname(nickname)
+                .profileImage(profileImageUrl)
+                .email(email)
                 .status(user.getStatus().name())
                 .build();
 
@@ -88,9 +95,9 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
         addCookie(response, "refreshToken", refreshToken, true, 60 * 60 * 24 * 7); // 7일
         addCookie(response, "userId", String.valueOf(user.getId()), true, 60 * 60 * 4);
         addCookie(response, "provider", user.getProvider().toString(), false, 60 * 60 * 4);
-        addCookie(response, "nickname", user.getNickname(), false, 60 * 60 * 4);
-        addCookie(response, "profileImage", user.getProfileImage().getImageUrl(), false, 60 * 60 * 4);
-        addCookie(response, "email", user.getEmail(), false, 60 * 60 * 4);
+        addCookie(response, "nickname", nickname, false, 60 * 60 * 4);
+        addCookie(response, "profileImage", profileImageUrl, false, 60 * 60 * 4);
+        addCookie(response, "email", email, false, 60 * 60 * 4);
         addCookie(response, "userStatus", String.valueOf(user.getStatus()), false, 60 * 60 * 4);
 
         // 2. 상태 정보: HttpOnly = false (JS에서 읽게)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,7 +28,7 @@ spring:
         format_sql: true
         use_sql_comments: true
         hbm2ddl:
-          auto: update #create #update #validate
+          auto: create #create #update #validate
         default_batch_fetch_size: 1000
   data:
     web:


### PR DESCRIPTION
## #️⃣ 기능 설명
> 개발 전 total_posts, correction_received, correction_given에 대해 이렇게 결정했었고, 코드가 추가되어 응답에 주석처리했던 부분을 구현함
<img width="295" height="356" alt="image" src="https://github.com/user-attachments/assets/1c71337e-0945-41d2-83f0-3ac2ccb5f796" />

## 🛠️ 작업 상세 내용
- [x]  GET [/api/user/me] 회원 정보 조회 API에 total_posts, correction_received, correction_given을 응답에 추가

## 📸 스크린샷 (선택)

## 💬 기타(공유사항 to 리뷰어)
질문이 있는데,
POST [/api/correction] 커렉션 글 작성 을 2번 성공한 후,
<img width="417" height="572" alt="image" src="https://github.com/user-attachments/assets/817e4e24-809b-44cd-b23f-a9370c173418" />

회원 정보 조회 api를 시도하니 아래처럼 total_posts, correction_received의 값이 2가 되었습니다.
<img width="402" height="408" alt="image" src="https://github.com/user-attachments/assets/dd0c5fc2-e9f0-41b4-b214-52ab3a727e13" />

1. totalPosts는 post(게시물)을 올릴 때만 카운트되는게 아니라, 게시물 올리기+커렉션 도움주기+커렉션 도움받기 이 셋의 합인가요?
2. 아래 사진의 주석처리된 설명처럼 커렉션 글 작성을 하는건 도움을 준 것이라고 생각했는데, 제 이해가 맞을까요? 
<img width="1004" height="121" alt="image" src="https://github.com/user-attachments/assets/decdcc4b-32f1-42d8-bab1-e42c63fb2627" />

3. total_posts가 post 테이블의 로그인한 user_id 수 맞는지
(참고로 UserQueryServiceImpl의 getUserInfo에서 long totalPosts = postRepository.countByAuthor_Id(user.getId());라고 동작하게 구현했습니다.)

4. correction_received은 feedback 테이블의 user_id 수가 맞는지
(참고로 UserQueryServiceImpl의 getUserInfo에서 long correctionsReceived = correctionRepository.countByPost_Author_Id(user.getId());라고 동작하게 구현했습니다.)

5. correction_given -> correction테이블의 user_id 수가 맞는지 확인하고 싶습니다.
(참고로 UserQueryServiceImpl의 getUserInfo에서 long correctionsGiven = correctionFeedbackRepository.countByCorrector_Id(user.getId());라고 동작하게 구현했습니다.)

6. 하나의 글에 커렉션이 여러 개 달리면 그 게시물 하나로 카운트하는지, 커렉션 개수를 각각 모두 카운트하는지