### PR TITLE
✨ [Feat] 커렉션 임시저장 CRUD 구현

### DIFF
--- a/src/main/java/verbly/spring/domain/correction/controller/CorrectionController.java
+++ b/src/main/java/verbly/spring/domain/correction/controller/CorrectionController.java
@@ -36,8 +36,12 @@ public class CorrectionController {
             security = @SecurityRequirement(name = "JWT TOKEN"),
             description = "새로운 글을 작성합니다.\n\n" +
                     "✅ 요청 본문에 포함할 수 있는 값:\n" +
+                    "- tempPostId: 임시저장 글 ID (Long, 선택)\n" +
                     "- title: 제목 (String, 필수)\n" +
-                    "- content: 내용 (String, 필수)\n"
+                    "- content: 내용 (String, 필수)\n\n" +
+                    "✅ 동작 방식:\n" +
+                    "- tempPostId가 없으면: 새 Post 및 Correction 생성\n" +
+                    "- tempPostId가 있으면: 임시저장 Post를 Correction 생성(요청)"
     )
     @io.swagger.v3.oas.annotations.parameters.RequestBody(
             description = "Correction Write 요청 예시",
@@ -46,13 +50,23 @@ public class CorrectionController {
                     mediaType = "application/json",
                     examples = {
                             @ExampleObject(
-                                    name = "Correction Write 요청 예시",
+                                    name = "새 글 제출",
                                     value = """
-                                            {
-                                                "title" : "제목",
-                                                "content" : "내용"
-                                            }
-                                            """
+                                        {
+                                          "title": "제목",
+                                          "content": "내용"
+                                        }
+                                        """
+                            ),
+                            @ExampleObject(
+                                    name = "임시저장 글 제출",
+                                    value = """
+                                        {
+                                          "tempPostId": 123,
+                                          "title": "임시저장했던 제목(수정 가능)",
+                                          "content": "임시저장했던 내용(수정 가능)"
+                                        }
+                                        """
                             )
                     }
             )

--- a/src/main/java/verbly/spring/domain/correction/controller/CorrectionController.java
+++ b/src/main/java/verbly/spring/domain/correction/controller/CorrectionController.java
@@ -72,7 +72,7 @@ public class CorrectionController {
      * Correction - 내 문서 조회
      */
     @Operation(
-            summary = "커렉션 - 내 문서 조회",
+            summary = "커렉션 - 내 문서 목록 조회",
             description = "자신이 작성한 커렉션 글 목록을 조회합니다.\n\n" +
                     "### QueryString\n" +
                     "모든 쿼리 파라미터는 **선택(Optional)**입니다.\n\n" +
@@ -105,6 +105,26 @@ public class CorrectionController {
                 .status(SuccessStatus.CORRECTION_READ_SUCCESS.getHttpStatus())
                 .body(ApiResponse.of(SuccessStatus.CORRECTION_READ_SUCCESS, result));
     }
+
+    /**
+     * Correction - 내 문서 상세 조회
+     */
+    @Operation(
+            summary = "커렉션 내 문서 상세 조회",
+            security = @SecurityRequirement(name = "JWT TOKEN"),
+            description = "자신이 작성한 커렉션 상세 정보를 조회합니다."
+    )
+    @GetMapping("/{correctionId}")
+    public ResponseEntity<ApiResponse<CorrectionResponseDTO.MyCorrectionDto>> getCorrectionDetail(
+            @PathVariable Long correctionId
+    ){
+        CorrectionResponseDTO.MyCorrectionDto result = correctionService.getCorrectionDetail(correctionId);
+
+        return ResponseEntity
+                .status(SuccessStatus.CORRECTION_READ_SUCCESS.getHttpStatus())
+                .body(ApiResponse.of(SuccessStatus.CORRECTION_READ_SUCCESS, result));
+    }
+
 
     /**
      * Correction - 문서 수정

--- a/src/main/java/verbly/spring/domain/correction/controller/TempPostController.java
+++ b/src/main/java/verbly/spring/domain/correction/controller/TempPostController.java
@@ -3,14 +3,14 @@ package verbly.spring.domain.correction.controller;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-import verbly.spring.domain.correction.dto.request.CorrectionRequestDTO;
+import org.springframework.web.bind.annotation.*;
 import verbly.spring.domain.correction.service.TempPostService;
+import verbly.spring.domain.post.dto.request.PostRequestDTO;
+import verbly.spring.domain.post.dto.response.PostResponseDTO;
 import verbly.spring.global.common.code.SuccessStatus;
 import verbly.spring.global.common.response.ApiResponse;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/temp-posts")
@@ -23,10 +23,51 @@ public class TempPostController {
      */
     @PostMapping
     public ResponseEntity<ApiResponse<Long>> createTempPost(
-            @RequestBody @Valid CorrectionRequestDTO.CreateDTO request
+            @RequestBody @Valid PostRequestDTO request
     ) {
         Long postId = tempPostService.createTempPost(request);
         return ResponseEntity.status(SuccessStatus.CORRECTION_TEMP_CREATE_SUCCESS.getHttpStatus())
                 .body(ApiResponse.of(SuccessStatus.CORRECTION_TEMP_CREATE_SUCCESS, postId));
+    }
+
+    /**
+     * Correction - 임시저장된 글 수정
+     */
+    @PatchMapping("/{postId}")
+    public ResponseEntity<ApiResponse<PostResponseDTO.Summary>> updateTempPost(
+            @PathVariable Long postId,
+            @RequestBody @Valid PostRequestDTO request
+    ){
+        PostResponseDTO.Summary result = tempPostService.updateTempPost(postId, request);
+        return ResponseEntity
+                .status(SuccessStatus.CORRECTION_TEMP_UPDATE_SUCCESS.getHttpStatus())
+                .body(ApiResponse.of(SuccessStatus.CORRECTION_TEMP_UPDATE_SUCCESS, result));
+    }
+
+    /**
+     * Correction - 임시저장된 글 목록 조회
+     */
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<PostResponseDTO.Summary>>> getAllTempPosts() {
+        List<PostResponseDTO.Summary> result =
+                tempPostService.getAllTempPosts();
+
+        return ResponseEntity
+                .status(SuccessStatus.CORRECTION_TEMP_READ_SUCCESS.getHttpStatus())
+                .body(ApiResponse.of(SuccessStatus.CORRECTION_TEMP_READ_SUCCESS, result));
+    }
+
+    /**
+     * Correction - 임시저장된 글 상세 조회
+     */
+    @GetMapping("/{postId}")
+    public ResponseEntity<ApiResponse<PostResponseDTO.Detail>> getMyTempPost(
+            @PathVariable Long postId
+    ) {
+        PostResponseDTO.Detail result = tempPostService.getMyTempPost(postId);
+
+        return ResponseEntity
+                .status(SuccessStatus.CORRECTION_TEMP_READ_SUCCESS.getHttpStatus())
+                .body(ApiResponse.of(SuccessStatus.CORRECTION_TEMP_READ_SUCCESS, result));
     }
 }

--- a/src/main/java/verbly/spring/domain/correction/controller/TempPostController.java
+++ b/src/main/java/verbly/spring/domain/correction/controller/TempPostController.java
@@ -1,5 +1,10 @@
 package verbly.spring.domain.correction.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -13,6 +18,7 @@ import verbly.spring.global.common.response.ApiResponse;
 
 import java.util.List;
 
+@Tag(name = "Temp Post", description = "Correction 탭 임시저장 API")
 @RestController
 @RequestMapping("/api/temp-posts")
 @RequiredArgsConstructor
@@ -23,6 +29,33 @@ public class TempPostController {
     /**
      * Correction - 글 임시저장
      */
+    @Operation(
+            summary = "커렉션 글 임시저장",
+            security = @SecurityRequirement(name = "JWT TOKEN"),
+            description = "새로운 글을 임시저장합니다.\n\n" +
+                    "✅ 요청 본문에 포함할 수 있는 값:\n" +
+                    "- title: 제목 (String, 필수)\n" +
+                    "- content: 내용 (String, 필수)\n"
+    )
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            description = "Correction 임시저장 요청 예시",
+            required = true,
+            content = @Content(
+                    mediaType = "application/json",
+                    examples = {
+                            @ExampleObject(
+                                    name = "Correction 임시저장 요청 예시",
+                                    value = """
+                                            {
+                                                "title" : "제목",
+                                                "content" : "내용"
+                                            }
+                                            """
+                            )
+                    }
+            )
+
+    )
     @PostMapping
     public ResponseEntity<ApiResponse<Long>> createTempPost(
             @RequestBody @Valid PostRequestDTO request
@@ -35,6 +68,30 @@ public class TempPostController {
     /**
      * Correction - 임시저장된 글 수정
      */
+    @Operation(
+            summary = "커렉션 임시저장 글 수정",
+            description = "자신의 임시저장 글을 수정합니다.\n\n" +
+                    "✅ 수정 가능한 값:\n" +
+                    "- title: 제목 (String, 선택)\n" +
+                    "- content: 내용 (String, 선택)\n",
+            security = { @SecurityRequirement(name = "JWT TOKEN") }
+    )
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            description = "Correction 임시저장 수정 요청 예시",
+            required = true,
+            content = @Content(
+                    mediaType = "application/json",
+                    examples = @ExampleObject(
+                            name = "Correction 임시저장 수정 요청 예시",
+                            value = """
+                                    {
+                                        "title": "수정된 제목",
+                                        "content": "수정된 내용"
+                                    }
+                                    """
+                    )
+            )
+    )
     @PatchMapping("/{postId}")
     public ResponseEntity<ApiResponse<PostResponseDTO.Detail>> updateTempPost(
             @PathVariable Long postId,
@@ -49,6 +106,11 @@ public class TempPostController {
     /**
      * Correction - 임시저장된 글 목록 조회
      */
+    @Operation(
+            summary = "커렉션 - 내 임시저장 문서 목록 조회",
+            description = "자신이 임시저장한 커렉션 글 목록을 조회합니다.\n\n",
+            security = { @SecurityRequirement(name = "JWT TOKEN") }
+    )
     @GetMapping
     public ResponseEntity<ApiResponse<List<PostResponseDTO.Summary>>> getAllTempPosts() {
         List<PostResponseDTO.Summary> result =
@@ -62,6 +124,11 @@ public class TempPostController {
     /**
      * Correction - 임시저장된 글 상세 조회
      */
+    @Operation(
+            summary = "커렉션 - 내 임시저장 문서 상세 조회",
+            description = "자신이 임시저장한 커렉션 글을 조회합니다.\n\n",
+            security = { @SecurityRequirement(name = "JWT TOKEN") }
+    )
     @GetMapping("/{postId}")
     public ResponseEntity<ApiResponse<PostResponseDTO.Detail>> getMyTempPost(
             @PathVariable Long postId
@@ -76,6 +143,11 @@ public class TempPostController {
     /**
      * Correction - 임시저장된 글 삭제
      */
+    @Operation(
+            summary = "커렉션 임시저장 글 삭제",
+            description = "자신의 커렉션 임시저장 글을 삭제합니다.",
+            security = { @SecurityRequirement(name = "JWT TOKEN") }
+    )
     @DeleteMapping("/{postId}")
     public ResponseEntity<ApiResponse<Void>> deleteTempPost(
             @PathVariable Long postId

--- a/src/main/java/verbly/spring/domain/correction/controller/TempPostController.java
+++ b/src/main/java/verbly/spring/domain/correction/controller/TempPostController.java
@@ -1,0 +1,32 @@
+package verbly.spring.domain.correction.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import verbly.spring.domain.correction.dto.request.CorrectionRequestDTO;
+import verbly.spring.domain.correction.service.TempPostService;
+import verbly.spring.global.common.code.SuccessStatus;
+import verbly.spring.global.common.response.ApiResponse;
+
+@RestController
+@RequestMapping("/api/temp-posts")
+@RequiredArgsConstructor
+public class TempPostController {
+    private final TempPostService tempPostService;
+
+    /**
+     * Correction - 글 임시저장
+     */
+    @PostMapping
+    public ResponseEntity<ApiResponse<Long>> createTempPost(
+            @RequestBody @Valid CorrectionRequestDTO.CreateDTO request
+    ) {
+        Long postId = tempPostService.createTempPost(request);
+        return ResponseEntity.status(SuccessStatus.CORRECTION_TEMP_CREATE_SUCCESS.getHttpStatus())
+                .body(ApiResponse.of(SuccessStatus.CORRECTION_TEMP_CREATE_SUCCESS, postId));
+    }
+}

--- a/src/main/java/verbly/spring/domain/correction/controller/TempPostController.java
+++ b/src/main/java/verbly/spring/domain/correction/controller/TempPostController.java
@@ -18,7 +18,7 @@ import verbly.spring.global.common.response.ApiResponse;
 
 import java.util.List;
 
-@Tag(name = "Temp Post", description = "Correction 탭 임시저장 API")
+@Tag(name = "Correction - Temp Post", description = "Correction 탭 임시저장 API")
 @RestController
 @RequestMapping("/api/temp-posts")
 @RequiredArgsConstructor

--- a/src/main/java/verbly/spring/domain/correction/controller/TempPostController.java
+++ b/src/main/java/verbly/spring/domain/correction/controller/TempPostController.java
@@ -4,6 +4,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import verbly.spring.domain.correction.service.CorrectionService;
 import verbly.spring.domain.correction.service.TempPostService;
 import verbly.spring.domain.post.dto.request.PostRequestDTO;
 import verbly.spring.domain.post.dto.response.PostResponseDTO;
@@ -17,6 +18,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class TempPostController {
     private final TempPostService tempPostService;
+    private final CorrectionService correctionService;
 
     /**
      * Correction - 글 임시저장
@@ -34,11 +36,11 @@ public class TempPostController {
      * Correction - 임시저장된 글 수정
      */
     @PatchMapping("/{postId}")
-    public ResponseEntity<ApiResponse<PostResponseDTO.Summary>> updateTempPost(
+    public ResponseEntity<ApiResponse<PostResponseDTO.Detail>> updateTempPost(
             @PathVariable Long postId,
             @RequestBody @Valid PostRequestDTO request
     ){
-        PostResponseDTO.Summary result = tempPostService.updateTempPost(postId, request);
+        PostResponseDTO.Detail result = tempPostService.updateTempPost(postId, request);
         return ResponseEntity
                 .status(SuccessStatus.CORRECTION_TEMP_UPDATE_SUCCESS.getHttpStatus())
                 .body(ApiResponse.of(SuccessStatus.CORRECTION_TEMP_UPDATE_SUCCESS, result));
@@ -69,5 +71,18 @@ public class TempPostController {
         return ResponseEntity
                 .status(SuccessStatus.CORRECTION_TEMP_READ_SUCCESS.getHttpStatus())
                 .body(ApiResponse.of(SuccessStatus.CORRECTION_TEMP_READ_SUCCESS, result));
+    }
+
+    /**
+     * Correction - 임시저장된 글 삭제
+     */
+    @DeleteMapping("/{postId}")
+    public ResponseEntity<ApiResponse<Void>> deleteTempPost(
+            @PathVariable Long postId
+    ){
+        tempPostService.deleteMyTempPost(postId);
+        return ResponseEntity
+                .status(SuccessStatus.CORRECTION_TEMP_DELETE_SUCCESS.getHttpStatus())
+                .body(ApiResponse.of(SuccessStatus.CORRECTION_TEMP_DELETE_SUCCESS, null));
     }
 }

--- a/src/main/java/verbly/spring/domain/correction/converter/CorrectionConverter.java
+++ b/src/main/java/verbly/spring/domain/correction/converter/CorrectionConverter.java
@@ -30,6 +30,7 @@ public class CorrectionConverter {
                 .correctorType(latestCorrectorType)
                 .correctorName(latestCorrectorName)
                 .correctionCreatedAt(correction.getCreatedAt())
+                .correctionUpdatedAt(correction.getUpdatedAt())
                 .status(post.getStatus())
                 .build();
     }

--- a/src/main/java/verbly/spring/domain/correction/dto/request/CorrectionRequestDTO.java
+++ b/src/main/java/verbly/spring/domain/correction/dto/request/CorrectionRequestDTO.java
@@ -13,6 +13,8 @@ public class CorrectionRequestDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class CreateDTO{
+        private Long tempPostId;
+
         @NotBlank(message = "글 제목은 필수입니다.")
         private String title;
 

--- a/src/main/java/verbly/spring/domain/correction/dto/response/CorrectionResponseDTO.java
+++ b/src/main/java/verbly/spring/domain/correction/dto/response/CorrectionResponseDTO.java
@@ -32,6 +32,7 @@ public class CorrectionResponseDTO {
         private String correctorName;
 
         private LocalDateTime correctionCreatedAt;
+        private LocalDateTime correctionUpdatedAt;
 
     }
 

--- a/src/main/java/verbly/spring/domain/correction/repository/CorrectionQueryRepository.java
+++ b/src/main/java/verbly/spring/domain/correction/repository/CorrectionQueryRepository.java
@@ -5,6 +5,7 @@ import verbly.spring.domain.correction.enums.CorrectorType;
 import verbly.spring.domain.post.enums.PostStatus;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface CorrectionQueryRepository {
     List<CorrectionResponseDTO.MyCorrectionDto> findMyCorrections(
@@ -13,5 +14,10 @@ public interface CorrectionQueryRepository {
             Boolean sort,
             PostStatus status,
             CorrectorType correctorType
+    );
+
+    Optional<CorrectionResponseDTO.MyCorrectionDto> findCorrectionDetail(
+            Long authorId,
+            Long correctionId
     );
 }

--- a/src/main/java/verbly/spring/domain/correction/repository/CorrectionQueryRepository.java
+++ b/src/main/java/verbly/spring/domain/correction/repository/CorrectionQueryRepository.java
@@ -15,9 +15,4 @@ public interface CorrectionQueryRepository {
             PostStatus status,
             CorrectorType correctorType
     );
-
-    Optional<CorrectionResponseDTO.MyCorrectionDto> findCorrectionDetail(
-            Long authorId,
-            Long correctionId
-    );
 }

--- a/src/main/java/verbly/spring/domain/correction/repository/CorrectionQueryRepositoryImpl.java
+++ b/src/main/java/verbly/spring/domain/correction/repository/CorrectionQueryRepositoryImpl.java
@@ -12,6 +12,7 @@ import verbly.spring.domain.correction.enums.CorrectorType;
 import verbly.spring.domain.post.enums.PostStatus;
 
 import java.util.List;
+import java.util.Optional;
 
 import static verbly.spring.domain.correction.entity.QCorrection.correction;
 import static verbly.spring.domain.correction.entity.QCorrectionFeedback.correctionFeedback;
@@ -74,7 +75,8 @@ public class CorrectionQueryRepositoryImpl implements CorrectionQueryRepository{
                         correction.bookmark.as("bookmark"),
                         latestFeedback.correctorType.as("correctorType"),
                         correctorNameExpr.as("correctorName"),
-                        correction.createdAt.as("correctionCreatedAt")
+                        correction.createdAt.as("correctionCreatedAt"),
+                        correction.updatedAt.as("correctionUpdatedAt")
                 ))
                 .from(correction)
                 .join(correction.post, post)
@@ -99,4 +101,54 @@ public class CorrectionQueryRepositoryImpl implements CorrectionQueryRepository{
         return baseQuery.fetch();
     }
 
+    @Override
+    public Optional<CorrectionResponseDTO.MyCorrectionDto> findCorrectionDetail(Long authorId, Long correctionId) {
+        BooleanBuilder where = new BooleanBuilder();
+        where.and(post.author.id.eq(authorId));
+        where.and(correction.id.eq(correctionId));
+
+        var latestCreatedAtSubQuery =
+                JPAExpressions.select(correctionFeedback.createdAt.max())
+                        .from(correctionFeedback)
+                        .where(correctionFeedback.correction.eq(correction));
+
+        var latestFeedback = new verbly.spring.domain.correction.entity.QCorrectionFeedback("latestFeedback");
+
+        var correctorNameExpr = new CaseBuilder()
+                .when(latestFeedback.correctorType.eq(CorrectorType.AI_ASSISTANT))
+                .then("AI Assistant")
+                .when(latestFeedback.correctorType.eq(CorrectorType.NATIVE_SPEAKER))
+                .then(user.nickname)
+                .otherwise((String) null);
+
+        var result = queryFactory
+                .select(Projections.fields(
+                        CorrectionResponseDTO.MyCorrectionDto.class,
+                        correction.id.as("correctionId"),
+                        post.id.as("postId"),
+                        post.title.as("title"),
+                        post.content.as("content"),
+                        post.status.as("status"),
+                        correction.bookmark.as("bookmark"),
+
+                        latestFeedback.correctorType.as("correctorType"),
+                        correctorNameExpr.as("correctorName"),
+                        latestFeedback.createdAt.as("latestFeedbackCreatedAt"),
+
+                        correction.createdAt.as("correctionCreatedAt"),
+                        correction.updatedAt.as("correctionUpdatedAt")
+                ))
+                .from(correction)
+                .join(correction.post, post)
+                .leftJoin(latestFeedback)
+                .on(
+                        latestFeedback.correction.eq(correction)
+                                .and(latestFeedback.createdAt.eq(latestCreatedAtSubQuery))
+                )
+                .leftJoin(latestFeedback.corrector, user)
+                .where(where)
+                .fetchOne();
+
+        return Optional.ofNullable(result);
+    }
 }

--- a/src/main/java/verbly/spring/domain/correction/repository/CorrectionQueryRepositoryImpl.java
+++ b/src/main/java/verbly/spring/domain/correction/repository/CorrectionQueryRepositoryImpl.java
@@ -33,6 +33,30 @@ public class CorrectionQueryRepositoryImpl implements CorrectionQueryRepository 
             PostStatus status,
             CorrectorType correctorType
     ) {
+        // TEMP일 경우
+        if (status == PostStatus.TEMP) {
+            return queryFactory
+                    .select(Projections.fields(
+                            CorrectionResponseDTO.MyCorrectionDto.class,
+                            post.id.as("postId"),
+                            post.title.as("title"),
+                            post.content.as("content"),
+                            post.status.as("status"),
+                            post.createdAt.as("correctionCreatedAt"),
+                            post.updatedAt.as("correctionUpdatedAt")
+                    ))
+                    .from(post)
+                    .where(
+                            post.author.id.eq(authorId),
+                            post.status.eq(PostStatus.TEMP)
+                    )
+                    .orderBy(
+                            Boolean.TRUE.equals(sort)
+                                    ? post.createdAt.desc()
+                                    : post.id.desc()
+                    )
+                    .fetch();
+        }
         BooleanBuilder where = new BooleanBuilder();
 
         where.and(post.author.id.eq(authorId));

--- a/src/main/java/verbly/spring/domain/correction/repository/CorrectionQueryRepositoryImpl.java
+++ b/src/main/java/verbly/spring/domain/correction/repository/CorrectionQueryRepositoryImpl.java
@@ -21,7 +21,7 @@ import static verbly.spring.domain.user.entity.QUser.user;
 
 @Repository
 @RequiredArgsConstructor
-public class CorrectionQueryRepositoryImpl implements CorrectionQueryRepository{
+public class CorrectionQueryRepositoryImpl implements CorrectionQueryRepository {
 
     private final JPAQueryFactory queryFactory;
 
@@ -99,56 +99,5 @@ public class CorrectionQueryRepositoryImpl implements CorrectionQueryRepository{
         }
 
         return baseQuery.fetch();
-    }
-
-    @Override
-    public Optional<CorrectionResponseDTO.MyCorrectionDto> findCorrectionDetail(Long authorId, Long correctionId) {
-        BooleanBuilder where = new BooleanBuilder();
-        where.and(post.author.id.eq(authorId));
-        where.and(correction.id.eq(correctionId));
-
-        var latestCreatedAtSubQuery =
-                JPAExpressions.select(correctionFeedback.createdAt.max())
-                        .from(correctionFeedback)
-                        .where(correctionFeedback.correction.eq(correction));
-
-        var latestFeedback = new verbly.spring.domain.correction.entity.QCorrectionFeedback("latestFeedback");
-
-        var correctorNameExpr = new CaseBuilder()
-                .when(latestFeedback.correctorType.eq(CorrectorType.AI_ASSISTANT))
-                .then("AI Assistant")
-                .when(latestFeedback.correctorType.eq(CorrectorType.NATIVE_SPEAKER))
-                .then(user.nickname)
-                .otherwise((String) null);
-
-        var result = queryFactory
-                .select(Projections.fields(
-                        CorrectionResponseDTO.MyCorrectionDto.class,
-                        correction.id.as("correctionId"),
-                        post.id.as("postId"),
-                        post.title.as("title"),
-                        post.content.as("content"),
-                        post.status.as("status"),
-                        correction.bookmark.as("bookmark"),
-
-                        latestFeedback.correctorType.as("correctorType"),
-                        correctorNameExpr.as("correctorName"),
-                        latestFeedback.createdAt.as("latestFeedbackCreatedAt"),
-
-                        correction.createdAt.as("correctionCreatedAt"),
-                        correction.updatedAt.as("correctionUpdatedAt")
-                ))
-                .from(correction)
-                .join(correction.post, post)
-                .leftJoin(latestFeedback)
-                .on(
-                        latestFeedback.correction.eq(correction)
-                                .and(latestFeedback.createdAt.eq(latestCreatedAtSubQuery))
-                )
-                .leftJoin(latestFeedback.corrector, user)
-                .where(where)
-                .fetchOne();
-
-        return Optional.ofNullable(result);
     }
 }

--- a/src/main/java/verbly/spring/domain/correction/repository/CorrectionRepository.java
+++ b/src/main/java/verbly/spring/domain/correction/repository/CorrectionRepository.java
@@ -7,4 +7,5 @@ import java.util.Optional;
 
 public interface CorrectionRepository extends JpaRepository<Correction, Long> {
     long countByPost_Author_Id(Long authorId);
+    boolean existsByPostId(Long postId);
 }

--- a/src/main/java/verbly/spring/domain/correction/repository/CorrectionRepository.java
+++ b/src/main/java/verbly/spring/domain/correction/repository/CorrectionRepository.java
@@ -6,7 +6,5 @@ import verbly.spring.domain.correction.entity.Correction;
 import java.util.Optional;
 
 public interface CorrectionRepository extends JpaRepository<Correction, Long> {
-    Optional<Correction> findByPostId(Long postId);
-    boolean existsByPostId(Long postId);
     long countByPost_Author_Id(Long authorId);
 }

--- a/src/main/java/verbly/spring/domain/correction/service/CorrectionService.java
+++ b/src/main/java/verbly/spring/domain/correction/service/CorrectionService.java
@@ -51,6 +51,14 @@ public class CorrectionService {
         );
     }
 
+    public CorrectionResponseDTO.MyCorrectionDto getCorrectionDetail(Long correctionId){
+        Long userId = SecurityUtils.getCurrentUserId();
+
+        Correction correction = findOwnedCorrectionOrThrow(userId, correctionId);
+
+        return CorrectionConverter.toMyCorrectionDTO(correction, null, null);
+    }
+
 
     /**
      * 새 글 작성 (첨삭 요청)
@@ -169,5 +177,4 @@ public class CorrectionService {
                 .filter(c -> c.getPost().getAuthor().getId().equals(userId))
                 .orElseThrow(() -> new CorrectionHandler(ErrorStatus.CORRECTION_ACCESS_DENIED));
     }
-
 }

--- a/src/main/java/verbly/spring/domain/correction/service/CorrectionService.java
+++ b/src/main/java/verbly/spring/domain/correction/service/CorrectionService.java
@@ -62,6 +62,8 @@ public class CorrectionService {
 
     /**
      * 새 글 작성 (첨삭 요청)
+     * - tempPostId 없으면: 새 Post, Correction 생성
+     * - tempPostId 있으면: TEMP Post 제출(PENDING) + Correction 생성
      */
     @Transactional
     public CorrectionResponseDTO.CreateCorrectionResponseDTO createCorrection(CorrectionRequestDTO.CreateDTO requestDTO) {
@@ -72,6 +74,27 @@ public class CorrectionService {
 
         validateRequiredFields(title, content);
 
+        // 임시저장 글 커렉션 요청할 경우
+        if (requestDTO.getTempPostId() != null) {
+            Long tempPostId = requestDTO.getTempPostId();
+
+            Post post = findTempPostOrThrow(tempPostId, user);
+
+            post.update(title, content);
+            post.changeStatus(PostStatus.PENDING);
+            post.changeTemp(false);
+
+            Post savedPost = postRepository.save(post);
+
+            Correction correction = Correction.builder()
+                    .post(savedPost)
+                    .build();
+
+            Correction savedCorrection = correctionRepository.save(correction);
+            return CorrectionConverter.toCreateCorrectionResponse(savedCorrection);
+        }
+
+        // 새 글 및 커렉션 생성
         Post post = Post.builder()
                 .author(user)
                 .status(PostStatus.PENDING)
@@ -176,5 +199,36 @@ public class CorrectionService {
         return correctionRepository.findById(correctionId)
                 .filter(c -> c.getPost().getAuthor().getId().equals(userId))
                 .orElseThrow(() -> new CorrectionHandler(ErrorStatus.CORRECTION_ACCESS_DENIED));
+    }
+
+    private Post findTempPostOrThrow(Long tempPostId, User user) {
+        Post post = findPostOrThrow(tempPostId);
+        validatePostOwner(post, user);
+        validateTempPostStatus(post);
+        validateNotAlreadySubmitted(post.getId());
+        return post;
+    }
+
+    private Post findPostOrThrow(Long postId) {
+        return postRepository.findById(postId)
+                .orElseThrow(() -> new CorrectionHandler(ErrorStatus.CORRECTION_TEMP_POST_NOT_FOUND));
+    }
+
+    private void validatePostOwner(Post post, User user) {
+        if (!post.getAuthor().getId().equals(user.getId())) {
+            throw new CorrectionHandler(ErrorStatus.CORRECTION_ACCESS_DENIED);
+        }
+    }
+
+    private void validateTempPostStatus(Post post) {
+        if (post.getStatus() != PostStatus.TEMP) {
+            throw new CorrectionHandler(ErrorStatus.CORRECTION_TEMP_POST_NOT_FOUND);
+        }
+    }
+
+    private void validateNotAlreadySubmitted(Long postId) {
+        if (correctionRepository.existsByPostId(postId)) {
+            throw new CorrectionHandler(ErrorStatus.CORRECTION_TEMP_POST_ALREADY_SUBMITTED);
+        }
     }
 }

--- a/src/main/java/verbly/spring/domain/correction/service/CorrectionService.java
+++ b/src/main/java/verbly/spring/domain/correction/service/CorrectionService.java
@@ -32,7 +32,7 @@ public class CorrectionService {
     private final CorrectionFeedbackRepository correctionFeedbackRepository;
 
     /**
-     * 내 문서 조회
+     * 내 문서 목록 조회
      */
     public List<CorrectionResponseDTO.MyCorrectionDto> getMyCorrections(
             Boolean bookmark,

--- a/src/main/java/verbly/spring/domain/correction/service/CorrectionService.java
+++ b/src/main/java/verbly/spring/domain/correction/service/CorrectionService.java
@@ -23,7 +23,6 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class CorrectionService {
 
     private final PostRepository postRepository;
@@ -34,6 +33,7 @@ public class CorrectionService {
     /**
      * 내 문서 목록 조회
      */
+    @Transactional(readOnly = true)
     public List<CorrectionResponseDTO.MyCorrectionDto> getMyCorrections(
             Boolean bookmark,
             Boolean sort,

--- a/src/main/java/verbly/spring/domain/correction/service/TempPostService.java
+++ b/src/main/java/verbly/spring/domain/correction/service/TempPostService.java
@@ -6,11 +6,16 @@ import org.springframework.transaction.annotation.Transactional;
 import verbly.spring.domain.correction.converter.CorrectionConverter;
 import verbly.spring.domain.correction.dto.request.CorrectionRequestDTO;
 import verbly.spring.domain.correction.exception.CorrectionHandler;
+import verbly.spring.domain.post.converter.PostConverter;
+import verbly.spring.domain.post.dto.request.PostRequestDTO;
+import verbly.spring.domain.post.dto.response.PostResponseDTO;
 import verbly.spring.domain.post.entity.Post;
 import verbly.spring.domain.post.repository.PostRepository;
 import verbly.spring.domain.user.entity.User;
 import verbly.spring.global.common.code.ErrorStatus;
 import verbly.spring.global.security.utils.SecurityUtils;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -22,7 +27,7 @@ public class TempPostService {
      * Correction 글 임시저장
      */
     @Transactional
-    public Long createTempPost(CorrectionRequestDTO.CreateDTO request) {
+    public Long createTempPost(PostRequestDTO request) {
         User user = SecurityUtils.getCurrentUser();
         Post post = Post.builder()
                 .author(user)
@@ -38,7 +43,8 @@ public class TempPostService {
     /**
      * Correction 임시저장된 글 수정
      */
-    public Long updateTempPost(Long postId, CorrectionRequestDTO.UpdateDTO requestDTO) {
+    @Transactional
+    public PostResponseDTO.Summary updateTempPost(Long postId, PostRequestDTO requestDTO) {
         Long userId = SecurityUtils.getCurrentUserId();
         Post post = findOwnedPostOrThrow(userId, postId);
 
@@ -47,19 +53,49 @@ public class TempPostService {
 
         validateRequiredFields(newTitle, newContent);
 
-//        if (post.isSameContent(newTitle, newContent)) {
-//
-//        }
+        if (post.isSameContent(newTitle, newContent)) {
+            return PostConverter.toResponseSummaryDTO(post);
+        }
 
         post.update(newTitle, newContent);
-        postRepository.save(post);
 
-        return postId;
+        return PostConverter.toResponseSummaryDTO(post);
     }
 
+    /**
+     * Correction 임시저장된 글 목록 조회
+     */
+    @Transactional
+    public List<PostResponseDTO.Summary> getAllTempPosts() {
+        Long userId = SecurityUtils.getCurrentUserId();
+        return postRepository.findAllByAuthorIdAndTempTrueOrderByCreatedAtDesc(userId)
+                .stream()
+                .map(PostConverter::toResponseSummaryDTO)
+                .toList();
+    }
+
+    /**
+     * Correction 임시저장된 글 상세 조회
+     */
+    @Transactional
+    public PostResponseDTO.Detail getMyTempPost(Long postId) {
+        Long userId = SecurityUtils.getCurrentUserId();
+        Post post = findOwnedPostOrThrow(userId, postId);
+
+        return PostConverter.toResponseDetailDTO(post);
+    }
+
+    /**
+     * Correction 임시저장된 글 삭제
+     */
+//    @Transactional
+//    public Long deleteMyTempPost(Long postId){
+//        Long userId = SecurityUtils.getCurrentUserId();
+//        Post post = findOwnedPostOrThrow(userId, postId);
+//    }
 
     private Post findOwnedPostOrThrow(Long userId,Long postId) {
-        return postRepository.findById(postId)
+        return postRepository.findByIdAndAuthorIdAndTempTrue(postId, userId)
                 .filter(c -> c.getAuthor().getId().equals(userId))
                 .orElseThrow(() -> new CorrectionHandler(ErrorStatus.CORRECTION_ACCESS_DENIED));
     }

--- a/src/main/java/verbly/spring/domain/correction/service/TempPostService.java
+++ b/src/main/java/verbly/spring/domain/correction/service/TempPostService.java
@@ -1,0 +1,81 @@
+package verbly.spring.domain.correction.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import verbly.spring.domain.correction.converter.CorrectionConverter;
+import verbly.spring.domain.correction.dto.request.CorrectionRequestDTO;
+import verbly.spring.domain.correction.exception.CorrectionHandler;
+import verbly.spring.domain.post.entity.Post;
+import verbly.spring.domain.post.repository.PostRepository;
+import verbly.spring.domain.user.entity.User;
+import verbly.spring.global.common.code.ErrorStatus;
+import verbly.spring.global.security.utils.SecurityUtils;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TempPostService {
+    private final PostRepository postRepository;
+
+    /**
+     * Correction 글 임시저장
+     */
+    @Transactional
+    public Long createTempPost(CorrectionRequestDTO.CreateDTO request) {
+        User user = SecurityUtils.getCurrentUser();
+        Post post = Post.builder()
+                .author(user)
+                .status(null)
+                .title(request.getTitle())
+                .content(request.getContent())
+                .temp(true)
+                .build();
+
+        return postRepository.save(post).getId();
+    }
+
+    /**
+     * Correction 임시저장된 글 수정
+     */
+    public Long updateTempPost(Long postId, CorrectionRequestDTO.UpdateDTO requestDTO) {
+        Long userId = SecurityUtils.getCurrentUserId();
+        Post post = findOwnedPostOrThrow(userId, postId);
+
+        String newTitle = normalize(defaultIfNull(requestDTO.getTitle(), post.getTitle()));
+        String newContent = normalize(defaultIfNull(requestDTO.getContent(), post.getContent()));
+
+        validateRequiredFields(newTitle, newContent);
+
+//        if (post.isSameContent(newTitle, newContent)) {
+//
+//        }
+
+        post.update(newTitle, newContent);
+        postRepository.save(post);
+
+        return postId;
+    }
+
+
+    private Post findOwnedPostOrThrow(Long userId,Long postId) {
+        return postRepository.findById(postId)
+                .filter(c -> c.getAuthor().getId().equals(userId))
+                .orElseThrow(() -> new CorrectionHandler(ErrorStatus.CORRECTION_ACCESS_DENIED));
+    }
+
+    private String normalize(String s) {
+        return s == null ? null : s.trim();
+    }
+
+    private String defaultIfNull(String value, String fallback) {
+        return value == null ? fallback : value;
+    }
+
+    private void validateRequiredFields(String title, String content) {
+        if (title == null || title.isEmpty() || content == null || content.isEmpty()) {
+            throw new CorrectionHandler(ErrorStatus.CORRECTION_NOT_VALIDATE);
+        }
+    }
+
+}

--- a/src/main/java/verbly/spring/domain/correction/service/TempPostService.java
+++ b/src/main/java/verbly/spring/domain/correction/service/TempPostService.java
@@ -10,6 +10,7 @@ import verbly.spring.domain.post.converter.PostConverter;
 import verbly.spring.domain.post.dto.request.PostRequestDTO;
 import verbly.spring.domain.post.dto.response.PostResponseDTO;
 import verbly.spring.domain.post.entity.Post;
+import verbly.spring.domain.post.enums.PostStatus;
 import verbly.spring.domain.post.repository.PostRepository;
 import verbly.spring.domain.user.entity.User;
 import verbly.spring.global.common.code.ErrorStatus;
@@ -19,7 +20,6 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class TempPostService {
     private final PostRepository postRepository;
 
@@ -31,7 +31,7 @@ public class TempPostService {
         User user = SecurityUtils.getCurrentUser();
         Post post = Post.builder()
                 .author(user)
-                .status(null)
+                .status(PostStatus.TEMP)
                 .title(request.getTitle())
                 .content(request.getContent())
                 .temp(true)
@@ -44,7 +44,7 @@ public class TempPostService {
      * Correction 임시저장된 글 수정
      */
     @Transactional
-    public PostResponseDTO.Summary updateTempPost(Long postId, PostRequestDTO requestDTO) {
+    public PostResponseDTO.Detail updateTempPost(Long postId, PostRequestDTO requestDTO) {
         Long userId = SecurityUtils.getCurrentUserId();
         Post post = findOwnedPostOrThrow(userId, postId);
 
@@ -54,18 +54,18 @@ public class TempPostService {
         validateRequiredFields(newTitle, newContent);
 
         if (post.isSameContent(newTitle, newContent)) {
-            return PostConverter.toResponseSummaryDTO(post);
+            return PostConverter.toResponseDetailDTO(post);
         }
 
         post.update(newTitle, newContent);
 
-        return PostConverter.toResponseSummaryDTO(post);
+        return PostConverter.toResponseDetailDTO(post);
     }
 
     /**
      * Correction 임시저장된 글 목록 조회
      */
-    @Transactional
+    @Transactional(readOnly = true)
     public List<PostResponseDTO.Summary> getAllTempPosts() {
         Long userId = SecurityUtils.getCurrentUserId();
         return postRepository.findAllByAuthorIdAndTempTrueOrderByCreatedAtDesc(userId)
@@ -77,7 +77,7 @@ public class TempPostService {
     /**
      * Correction 임시저장된 글 상세 조회
      */
-    @Transactional
+    @Transactional(readOnly = true)
     public PostResponseDTO.Detail getMyTempPost(Long postId) {
         Long userId = SecurityUtils.getCurrentUserId();
         Post post = findOwnedPostOrThrow(userId, postId);
@@ -88,11 +88,12 @@ public class TempPostService {
     /**
      * Correction 임시저장된 글 삭제
      */
-//    @Transactional
-//    public Long deleteMyTempPost(Long postId){
-//        Long userId = SecurityUtils.getCurrentUserId();
-//        Post post = findOwnedPostOrThrow(userId, postId);
-//    }
+    @Transactional
+    public void deleteMyTempPost(Long postId){
+        Long userId = SecurityUtils.getCurrentUserId();
+        Post post = findOwnedPostOrThrow(userId, postId);
+        postRepository.delete(post);
+    }
 
     private Post findOwnedPostOrThrow(Long userId,Long postId) {
         return postRepository.findByIdAndAuthorIdAndTempTrue(postId, userId)

--- a/src/main/java/verbly/spring/domain/post/converter/PostConverter.java
+++ b/src/main/java/verbly/spring/domain/post/converter/PostConverter.java
@@ -1,0 +1,30 @@
+package verbly.spring.domain.post.converter;
+
+import verbly.spring.domain.post.dto.response.PostResponseDTO;
+import verbly.spring.domain.post.entity.Post;
+
+public class PostConverter {
+    private PostConverter() {}
+
+    public static PostResponseDTO.Summary toResponseSummaryDTO(Post post) {
+        return PostResponseDTO.Summary.builder()
+                .postId(post.getId())
+                .authorId(post.getAuthor().getId())
+                .authorNickname(post.getAuthor().getNickname())
+                .content(post.getContent())
+                .createdAt(post.getCreatedAt())
+                .build();
+    }
+
+    public static PostResponseDTO.Detail toResponseDetailDTO(Post post) {
+        return PostResponseDTO.Detail.builder()
+                .postId(post.getId())
+                .authorId(post.getAuthor().getId())
+                .authorNickname(post.getAuthor().getNickname())
+                .content(post.getContent())
+                .status(post.getStatus())
+                .createdAt(post.getCreatedAt())
+                .updatedAt(post.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/verbly/spring/domain/post/converter/PostConverter.java
+++ b/src/main/java/verbly/spring/domain/post/converter/PostConverter.java
@@ -11,7 +11,7 @@ public class PostConverter {
                 .postId(post.getId())
                 .authorId(post.getAuthor().getId())
                 .authorNickname(post.getAuthor().getNickname())
-                .content(post.getContent())
+                .title(post.getTitle())
                 .createdAt(post.getCreatedAt())
                 .build();
     }
@@ -21,6 +21,7 @@ public class PostConverter {
                 .postId(post.getId())
                 .authorId(post.getAuthor().getId())
                 .authorNickname(post.getAuthor().getNickname())
+                .title(post.getTitle())
                 .content(post.getContent())
                 .status(post.getStatus())
                 .createdAt(post.getCreatedAt())

--- a/src/main/java/verbly/spring/domain/post/dto/request/PostRequestDTO.java
+++ b/src/main/java/verbly/spring/domain/post/dto/request/PostRequestDTO.java
@@ -7,9 +7,9 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class PostRequestDTO {
-    @NotBlank
+    @NotBlank(message = "글 제목은 필수입니다.")
     private String title;
 
-    @NotBlank
+    @NotBlank(message = "글 내용은 필수입니다.")
     private String content;
 }

--- a/src/main/java/verbly/spring/domain/post/dto/request/PostRequestDTO.java
+++ b/src/main/java/verbly/spring/domain/post/dto/request/PostRequestDTO.java
@@ -1,0 +1,15 @@
+package verbly.spring.domain.post.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PostRequestDTO {
+    @NotBlank
+    private String title;
+
+    @NotBlank
+    private String content;
+}

--- a/src/main/java/verbly/spring/domain/post/dto/response/PostResponseDTO.java
+++ b/src/main/java/verbly/spring/domain/post/dto/response/PostResponseDTO.java
@@ -4,17 +4,34 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import verbly.spring.domain.post.enums.PostStatus;
+
+import java.time.LocalDateTime;
 
 @Getter
 @Builder
 @AllArgsConstructor
 public class PostResponseDTO {
+
     @Getter
     @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class CreatePostResponseDTO {
-        private String title;
+    public static class Summary {
+        private Long postId;
+        private Long authorId;
+        private String authorNickname;
         private String content;
+        private LocalDateTime createdAt;
+    }
+
+    @Getter
+    @Builder
+    public static class Detail {
+        private Long postId;
+        private Long authorId;
+        private String authorNickname;
+        private String content;
+        private PostStatus status;
+        private LocalDateTime createdAt;
+        private LocalDateTime updatedAt;
     }
 }

--- a/src/main/java/verbly/spring/domain/post/dto/response/PostResponseDTO.java
+++ b/src/main/java/verbly/spring/domain/post/dto/response/PostResponseDTO.java
@@ -19,7 +19,7 @@ public class PostResponseDTO {
         private Long postId;
         private Long authorId;
         private String authorNickname;
-        private String content;
+        private String title;
         private LocalDateTime createdAt;
     }
 
@@ -29,6 +29,7 @@ public class PostResponseDTO {
         private Long postId;
         private Long authorId;
         private String authorNickname;
+        private String title;
         private String content;
         private PostStatus status;
         private LocalDateTime createdAt;

--- a/src/main/java/verbly/spring/domain/post/dto/response/PostResponseDTO.java
+++ b/src/main/java/verbly/spring/domain/post/dto/response/PostResponseDTO.java
@@ -1,0 +1,20 @@
+package verbly.spring.domain.post.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class PostResponseDTO {
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CreatePostResponseDTO {
+        private String title;
+        private String content;
+    }
+}

--- a/src/main/java/verbly/spring/domain/post/entity/Post.java
+++ b/src/main/java/verbly/spring/domain/post/entity/Post.java
@@ -24,9 +24,10 @@ public class Post extends BaseEntity {
     @JoinColumn(name = "author_id", nullable = false)
     private User author;
 
-    // 상태 (PENDING, IN_PROGRESS, COMPLETED)
+    // 상태 (null, PENDING, IN_PROGRESS, COMPLETED)
+    // null 인 경우: 임시저장
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false, length = 30)
+    @Column(nullable = true, length = 30)
     private PostStatus status;
 
     // 제목

--- a/src/main/java/verbly/spring/domain/post/entity/Post.java
+++ b/src/main/java/verbly/spring/domain/post/entity/Post.java
@@ -24,10 +24,10 @@ public class Post extends BaseEntity {
     @JoinColumn(name = "author_id", nullable = false)
     private User author;
 
-    // 상태 (null, PENDING, IN_PROGRESS, COMPLETED)
-    // null 인 경우: 임시저장
+    // 상태 (TEMP, PENDING, IN_PROGRESS, COMPLETED)
+    // TEMP 인 경우: 임시저장
     @Enumerated(EnumType.STRING)
-    @Column(nullable = true, length = 30)
+    @Column(nullable = false, length = 30)
     private PostStatus status;
 
     // 제목

--- a/src/main/java/verbly/spring/domain/post/entity/Post.java
+++ b/src/main/java/verbly/spring/domain/post/entity/Post.java
@@ -53,4 +53,12 @@ public class Post extends BaseEntity {
         return this.title.equals(title) && this.content.equals(content);
     }
 
+    public void changeStatus(PostStatus status) {
+        this.status = status;
+    }
+
+    public void changeTemp(boolean temp) {
+        this.temp = temp;
+    }
+
 }

--- a/src/main/java/verbly/spring/domain/post/enums/PostStatus.java
+++ b/src/main/java/verbly/spring/domain/post/enums/PostStatus.java
@@ -1,6 +1,7 @@
 package verbly.spring.domain.post.enums;
 
 public enum PostStatus {
+    TEMP,
     PENDING,
     IN_PROGRESS,
     COMPLETED

--- a/src/main/java/verbly/spring/domain/post/repository/PostRepository.java
+++ b/src/main/java/verbly/spring/domain/post/repository/PostRepository.java
@@ -4,9 +4,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import verbly.spring.domain.post.entity.Post;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
 
-    List<Post> findAllByAuthorIdOrderByIdDesc(Long authorId);
+    List<Post> findAllByAuthorIdAndTempTrueOrderByUpdatedAtDesc(Long authorId);
+    Optional<Post> findByIdAndAuthorIdAndTempTrue(Long postId, Long authorId);
 
 }

--- a/src/main/java/verbly/spring/domain/post/repository/PostRepository.java
+++ b/src/main/java/verbly/spring/domain/post/repository/PostRepository.java
@@ -10,7 +10,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     List<Post> findAllByAuthorIdOrderByIdDesc(Long authorId);
     long countByAuthor_Id(Long userId);
-    List<Post> findAllByAuthorIdAndTempTrueOrderByUpdatedAtDesc(Long authorId);
+    List<Post> findAllByAuthorIdAndTempTrueOrderByCreatedAtDesc(Long authorId);
     Optional<Post> findByIdAndAuthorIdAndTempTrue(Long postId, Long authorId);
 
 }

--- a/src/main/java/verbly/spring/global/common/code/ErrorStatus.java
+++ b/src/main/java/verbly/spring/global/common/code/ErrorStatus.java
@@ -41,6 +41,8 @@ public enum ErrorStatus implements BaseErrorCode {
     CORRECTION_NOT_FOUND(HttpStatus.NOT_FOUND, "CORRECTION4001", "문서를 찾을 수 없습니다."),
     CORRECTION_ACCESS_DENIED(HttpStatus.FORBIDDEN, "CORRECTION4002", "해당 문서에 대한 권한이 없습니다."),
     CORRECTION_NOT_VALIDATE(HttpStatus.BAD_REQUEST, "CORRECTION4003", "제목과 내용은 필수 입력 항목입니다."),
+    CORRECTION_TEMP_POST_NOT_FOUND(HttpStatus.NOT_FOUND, "CORRECTION4004", "임시저장 문서를 찾을 수 없습니다."),
+    CORRECTION_TEMP_POST_ALREADY_SUBMITTED(HttpStatus.BAD_REQUEST, "CORRECTION4005", "이미 Correction 요청한 문서입니다."),
 
     // 통계 관련 에러
     STATS_NOT_FOUND(HttpStatus.BAD_REQUEST, "STATS4001", "사용자 통계 정보가 존재하지 않습니다.");

--- a/src/main/java/verbly/spring/global/common/code/SuccessStatus.java
+++ b/src/main/java/verbly/spring/global/common/code/SuccessStatus.java
@@ -27,6 +27,10 @@ public enum SuccessStatus implements BaseCode {
     CORRECTION_DELETE_SUCCESS(HttpStatus.OK, "CORRECTION2004", "Correction - 글을 성공적으로 삭제했습니다."),
     CORRECTION_BOOKMARK_ADD_SUCCESS(HttpStatus.OK, "CORRECTION2005", "Correction - 글을 성공적으로 즐겨찾기에 추가했습니다."),
     CORRECTION_BOOKMARK_REMOVE_SUCCESS(HttpStatus.OK, "CORRECTION2006", "Correction - 글을 즐겨찾기에서 성공적으로 삭제했습니다"),
+    CORRECTION_TEMP_CREATE_SUCCESS(HttpStatus.CREATED, "CORRECTION2007", "Correction - 글을 성공적으로 임시저장했습니다."),
+
+
+
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/verbly/spring/global/common/code/SuccessStatus.java
+++ b/src/main/java/verbly/spring/global/common/code/SuccessStatus.java
@@ -30,6 +30,7 @@ public enum SuccessStatus implements BaseCode {
     CORRECTION_TEMP_CREATE_SUCCESS(HttpStatus.CREATED, "CORRECTION2007", "Correction - 글을 성공적으로 임시저장했습니다."),
     CORRECTION_TEMP_UPDATE_SUCCESS(HttpStatus.OK, "CORRECTION2008", "Correction - 임시저장 글을 성공적으로 수정했습니다."),
     CORRECTION_TEMP_READ_SUCCESS(HttpStatus.OK, "CORRECTION2009", "Correction - 임시저장 글을 성공적으로 조회했습니다."),
+    CORRECTION_TEMP_DELETE_SUCCESS(HttpStatus.OK, "CORRECTION2010", "Correction - 임시저장 글을 성공적으로 삭제했습니다."),
 
     ;
 

--- a/src/main/java/verbly/spring/global/common/code/SuccessStatus.java
+++ b/src/main/java/verbly/spring/global/common/code/SuccessStatus.java
@@ -28,8 +28,8 @@ public enum SuccessStatus implements BaseCode {
     CORRECTION_BOOKMARK_ADD_SUCCESS(HttpStatus.OK, "CORRECTION2005", "Correction - 글을 성공적으로 즐겨찾기에 추가했습니다."),
     CORRECTION_BOOKMARK_REMOVE_SUCCESS(HttpStatus.OK, "CORRECTION2006", "Correction - 글을 즐겨찾기에서 성공적으로 삭제했습니다"),
     CORRECTION_TEMP_CREATE_SUCCESS(HttpStatus.CREATED, "CORRECTION2007", "Correction - 글을 성공적으로 임시저장했습니다."),
-
-
+    CORRECTION_TEMP_UPDATE_SUCCESS(HttpStatus.OK, "CORRECTION2008", "Correction - 임시저장 글을 성공적으로 수정했습니다."),
+    CORRECTION_TEMP_READ_SUCCESS(HttpStatus.OK, "CORRECTION2009", "Correction - 임시저장 글을 성공적으로 조회했습니다."),
 
     ;
 

--- a/src/main/java/verbly/spring/global/security/config/SecurityConfig.java
+++ b/src/main/java/verbly/spring/global/security/config/SecurityConfig.java
@@ -46,7 +46,8 @@ public class SecurityConfig {
                 "http://3.36.90.173:3000",
                 "http://3.36.90.173:8080",
                 "http://localhost:3000", // 로컬 프론트
-                "http://localhost:8080" // 로컬 백엔드
+                "http://localhost:8080", // 로컬 백엔드
+                "http://localhost:5173" // 로컬 프론트
         ));
         config.setAllowedHeaders(List.of("*"));
         config.setExposedHeaders(List.of("Authorization"));  // JWT 토큰 읽기 허용

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,7 +28,7 @@ spring:
         format_sql: true
         use_sql_comments: true
         hbm2ddl:
-          auto: create #create #update #validate
+          auto: update #create #update #validate
         default_batch_fetch_size: 1000
   data:
     web:


### PR DESCRIPTION
## #️⃣ 기능 설명
커렉션 탭의 임시저장 CRUD를 구현하였습니다.

## 🛠️ 작업 상세 내용
- [x] 커렉션 임시저장 글 생성
- [x] 커렉션 임시저장 글 목록 조회
- [x] 커렉션 임시저장 글 상세 조회
- [x] 커렉션 임시저장 글 수정
- [x] 커렉션 임시저장 글 삭제
- [x] 커렉션 임시저장 글 -> 커렉션 요청 (`POST /api/correction`)

## 📸 스크린샷 (선택)

## 💬 기타(공유사항 to 리뷰어)
커렉션 임시저장 글 -> 커렉션 요청 (`POST /api/correction`) api 잘 되는지 확인 부탁드립니다!
(correction 생성 및 postStatus TEMP->PENDING 로직입니다)
