### PR TITLE
✨ [Feat] 라이브러리(퀴즈파트) api  완성

### DIFF
--- a/src/main/java/verbly/spring/domain/library/enums/ExampleSource.java
+++ b/src/main/java/verbly/spring/domain/library/enums/ExampleSource.java
@@ -1,5 +1,5 @@
 package verbly.spring.domain.library.enums;
 
 public enum ExampleSource {
-    AI, MANUAL, CORPUS
+    AI, MANUAL
 }

--- a/src/main/java/verbly/spring/domain/quizreview/controller/ReviewRestController.java
+++ b/src/main/java/verbly/spring/domain/quizreview/controller/ReviewRestController.java
@@ -119,7 +119,7 @@ public class ReviewRestController {
 
                     ✅ 요청 바디
                     - userAnswerJson: 프론트에서 보내는 사용자 답안 JSON(필수)
-                    - mistakeNote: 오답 노트(선택)
+                   
 
                     ✅ 응답
                     - 정답 여부/정답키/해설을 반환하며,
@@ -141,8 +141,8 @@ public class ReviewRestController {
                                     {
                                       "userAnswerJson": {
                                         "answer": "어색한 분위기를 깨다"
-                                      },
-                                      "mistakeNote": "뜻을 헷갈림"
+                                      }
+                                      
                                     }
                                     """
                     )

--- a/src/main/java/verbly/spring/domain/quizreview/converter/ReviewConverter.java
+++ b/src/main/java/verbly/spring/domain/quizreview/converter/ReviewConverter.java
@@ -32,9 +32,7 @@ public class ReviewConverter {
                 q.getLibraryItem().getPhrase(),
                 q.getQuestionType().name(),
                 q.getPrompt(),
-                options,
-                q.getHintTotal(),
-                q.getHintUsed()
+                options
         );
     }
 

--- a/src/main/java/verbly/spring/domain/quizreview/dto/request/ReviewRequestDTO.java
+++ b/src/main/java/verbly/spring/domain/quizreview/dto/request/ReviewRequestDTO.java
@@ -7,8 +7,7 @@ import jakarta.validation.constraints.Size;
 public class ReviewRequestDTO {
 
     public record QuizAnswerSubmitRequest(
-            @NotNull JsonNode userAnswerJson,
-            @Size(max = 1000) String mistakeNote
+            @NotNull JsonNode userAnswerJson
     ) {}
 
     public record QuizHintRequest() {}

--- a/src/main/java/verbly/spring/domain/quizreview/dto/response/ReviewResponseDTO.java
+++ b/src/main/java/verbly/spring/domain/quizreview/dto/response/ReviewResponseDTO.java
@@ -21,7 +21,8 @@ public class ReviewResponseDTO {
             Long questionId,
             int hintUsed,
             int hintTotal,
-            int hintRemaining
+            int hintRemaining,
+            String hint
     ) {}
 
     public record QuizMistakeResponse(
@@ -40,9 +41,8 @@ public class ReviewResponseDTO {
             String phrase,
             String questionType,
             String prompt,
-            List<String> options,
-            int hintTotal,
-            int hintUsed
+            List<String> options
+
     ) {}
 
     public  record QuizQuitResponse(

--- a/src/main/java/verbly/spring/domain/quizreview/entity/ReviewAnswer.java
+++ b/src/main/java/verbly/spring/domain/quizreview/entity/ReviewAnswer.java
@@ -43,28 +43,19 @@ public class ReviewAnswer {
     @Column(name = "is_correct", nullable = false)
     private boolean correct;
 
-    /**
-     * 오답노트
-     */
-    @Lob
-    @Column(name = "mistake_note", columnDefinition = "TEXT")
-    private String mistakeNote;
+
 
     @CreationTimestamp
     @Column(name = "answered_at", nullable = false, columnDefinition = "datetime(3)")
     private LocalDateTime answeredAt;
 
-    public static ReviewAnswer of(ReviewQuestion q, int attemptNo, JsonNode userAnswerJson, boolean correct, String mistakeNote) {
+    public static ReviewAnswer of(ReviewQuestion q, int attemptNo, JsonNode userAnswerJson, boolean correct) {
         ReviewAnswer a = new ReviewAnswer();
         a.reviewQuestion = q;
         a.attemptNo = attemptNo;
         a.userAnswerJson = userAnswerJson;
         a.correct = correct;
-        a.mistakeNote = mistakeNote;
         return a;
     }
 
-    public void updateMistakeNote(String note) {
-        this.mistakeNote = note;
-    }
 }

--- a/src/main/java/verbly/spring/domain/quizreview/entity/ReviewQuestion.java
+++ b/src/main/java/verbly/spring/domain/quizreview/entity/ReviewQuestion.java
@@ -67,15 +67,14 @@ public class ReviewQuestion {
     @Column(name = "explanation", columnDefinition = "TEXT")
     private String explanation;
 
-    /** 외부 FK: 글.Key (선택) */
+    /** 외부 FK: */
     @Column(name = "source_post_id")
     private Long sourcePostId;
 
-    @Column(name = "hint_total", nullable = false)
-    private int hintTotal = 2;
+    @Lob
+    @Column(name = "hint",columnDefinition = "TEXT")
+    private String hint;
 
-    @Column(name = "hint_used", nullable = false)
-    private int hintUsed = 0;
 
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, columnDefinition = "datetime(3)")
@@ -92,15 +91,9 @@ public class ReviewQuestion {
         q.prompt = prompt;
         q.optionsJson = optionsJson;
         q.answerKeyJson = answerKeyJson;
-        q.hintTotal = 2;
-        q.hintUsed = 0;
+
         return q;
     }
 
-    public void useHint() {
-        if (hintUsed >= hintTotal) {
-            throw new IllegalStateException("No hints remaining");
-        }
-        hintUsed += 1;
-    }
+
 }

--- a/src/main/java/verbly/spring/domain/quizreview/entity/ReviewSession.java
+++ b/src/main/java/verbly/spring/domain/quizreview/entity/ReviewSession.java
@@ -48,6 +48,11 @@ public class ReviewSession {
 
     @Column(name = "quit_at", columnDefinition = "datetime(3)")
     private LocalDateTime quitAt;
+    @Column(name = "hint_total", nullable = false)
+    private int hintTotal = 2;
+
+    @Column(name = "hint_used", nullable = false)
+    private int hintUsed = 0;
 
     public static ReviewSession start(Long userId, int totalTasks) {
         ReviewSession s = new ReviewSession();
@@ -55,6 +60,8 @@ public class ReviewSession {
         s.totalTasks = totalTasks;
         s.currentIndex = 1;
         s.status = ReviewSessionStatus.IN_PROGRESS;
+        s.hintTotal = 2;
+        s.hintUsed = 0;
         return s;
     }
 
@@ -65,6 +72,12 @@ public class ReviewSession {
     public void complete(LocalDateTime now) {
         this.status = ReviewSessionStatus.COMPLETED;
         this.completedAt = now;
+    }
+    public void useHint() {
+        if (hintUsed >= hintTotal) {
+            throw new IllegalStateException("No hints remaining");
+        }
+        hintUsed += 1;
     }
 
     public void quit(LocalDateTime now) {

--- a/src/main/java/verbly/spring/domain/quizreview/entity/ReviewSession.java
+++ b/src/main/java/verbly/spring/domain/quizreview/entity/ReviewSession.java
@@ -35,7 +35,7 @@ public class ReviewSession {
     @Column(name = "total_tasks", nullable = false)
     private int totalTasks;
 
-    /** 1-based든 0-based든 서비스에서 통일 (권장: 1-based) */
+
     @Column(name = "current_index", nullable = false)
     private int currentIndex = 1;
 

--- a/src/main/java/verbly/spring/domain/quizreview/repository/ReviewAnswerRepository.java
+++ b/src/main/java/verbly/spring/domain/quizreview/repository/ReviewAnswerRepository.java
@@ -9,6 +9,6 @@ import java.util.Optional;
 public interface ReviewAnswerRepository extends JpaRepository<ReviewAnswer, Long> {
 
     Optional<ReviewAnswer> findTopByReviewQuestion_IdOrderByAttemptNoDesc(Long reviewQuestionId);
-
+    void deleteAllByReviewQuestion_IdIn(List<Long> reviewQuestionIds);
     List<ReviewAnswer> findAllByReviewQuestion_IdInOrderByReviewQuestion_IdAscAttemptNoDesc(List<Long> reviewQuestionIds);
 }

--- a/src/main/java/verbly/spring/domain/quizreview/service/ReviewCommandServiceImpl.java
+++ b/src/main/java/verbly/spring/domain/quizreview/service/ReviewCommandServiceImpl.java
@@ -91,25 +91,27 @@ public class ReviewCommandServiceImpl implements ReviewCommandService {
         );
     }
 
-    @Override
     public ReviewResponseDTO.QuizHintResponse useHint(Long userId, Long sessionId, Long questionId) {
         ReviewSession session = reviewValidator.validateOwnedSessionForUpdate(userId, sessionId);
         reviewValidator.validateSessionInProgress(session);
 
         ReviewQuestion q = reviewValidator.validateQuestionWithTaskAndItem(questionId);
         reviewValidator.validateQuestionOwnership(userId, sessionId, q);
-
-        if (q.getHintUsed() >= q.getHintTotal()) {
+        // ✅ 세션 전체 힌트 제한 체크
+        if (session.getHintUsed() >= session.getHintTotal()) {
             throw new ReviewHandler(ErrorStatus.QUIZ_NO_HINTS_REMAINING);
         }
 
-        q.useHint();
+        // ✅ 세션 힌트 사용 1회 차감
+        session.useHint();
+        String textHint = q.getHint();
 
         return new ReviewResponseDTO.QuizHintResponse(
                 q.getId(),
-                q.getHintUsed(),
-                q.getHintTotal(),
-                Math.max(0, q.getHintTotal() - q.getHintUsed())
+                session.getHintUsed(),   // 이제 “세션 기준”으로 내려주는 게 더 자연스러움
+                session.getHintTotal(),
+                Math.max(0, session.getHintTotal() - session.getHintUsed()),
+                textHint
         );
     }
 

--- a/src/main/java/verbly/spring/domain/quizreview/service/ReviewCommandServiceImpl.java
+++ b/src/main/java/verbly/spring/domain/quizreview/service/ReviewCommandServiceImpl.java
@@ -145,8 +145,7 @@ public class ReviewCommandServiceImpl implements ReviewCommandService {
                 q,
                 nextAttempt,
                 request.userAnswerJson(),
-                correct,
-                request.mistakeNote()
+                correct
         );
         reviewAnswerRepository.save(answer);
 

--- a/src/main/java/verbly/spring/domain/quizreview/service/ReviewCommandServiceImpl.java
+++ b/src/main/java/verbly/spring/domain/quizreview/service/ReviewCommandServiceImpl.java
@@ -354,8 +354,7 @@ public class ReviewCommandServiceImpl implements ReviewCommandService {
     }
 
     private List<ReviewQuestion> generateQuestions(Long userId, List<ReviewTask> tasks) {
-        // NOTE: 실제 서비스에서는 AI 생성/코퍼스 생성으로 대체 가능
-        // 지금은 동작 가능한 최소 구현
+
 
         List<ReviewQuestion> result = new ArrayList<>();
 

--- a/src/main/java/verbly/spring/domain/quizreview/service/ReviewCommandServiceImpl.java
+++ b/src/main/java/verbly/spring/domain/quizreview/service/ReviewCommandServiceImpl.java
@@ -230,14 +230,27 @@ public class ReviewCommandServiceImpl implements ReviewCommandService {
                 .filter(t -> wrongTaskIds.contains(t.getId()))
                 .toList();
 
+        // 오답 task들만 PENDING으로 되돌리고
         for (ReviewTask t : wrongTasks) {
             t.rollbackToPending();
         }
         reviewTaskRepository.saveAll(wrongTasks);
 
-        reviewQuestionRepository.deleteAllByReviewTask_IdIn(new ArrayList<>(wrongTaskIds));
+    // 오답 task에 해당하는 questionIds 추출
+        List<Long> wrongQuestionIds = questions.stream()
+                .filter(q -> wrongTaskIds.contains(q.getReviewTask().getId()))
+                .map(ReviewQuestion::getId)
+                .toList();
 
-        // “오답만” 새 세션 시작
+
+        if (!wrongQuestionIds.isEmpty()) {
+            reviewAnswerRepository.deleteAllByReviewQuestion_IdIn(wrongQuestionIds);
+            reviewAnswerRepository.flush(); // 삭제 SQL 먼저 반영
+        }
+
+        reviewQuestionRepository.deleteAllByReviewTask_IdIn(new ArrayList<>(wrongTaskIds));
+        reviewQuestionRepository.flush(); // 삭제 SQL 먼저 반영
+
         return startSessionOnlyWithGivenPendingTasks(userId, wrongTasks);
     }
 
@@ -265,7 +278,18 @@ public class ReviewCommandServiceImpl implements ReviewCommandService {
         }
         reviewTaskRepository.saveAll(tasks);
 
-        // 문제/답 기록은 “이번 시도”는 의미 없으니 삭제(선택)
+        // 해당 task들의 questionId 수집
+        List<Long> questionIds = reviewQuestionRepository.findAllByReviewTask_IdIn(taskIds)
+                .stream()
+                .map(ReviewQuestion::getId)
+                .toList();
+
+
+        if (!questionIds.isEmpty()) {
+            reviewAnswerRepository.deleteAllByReviewQuestion_IdIn(questionIds);
+        }
+
+
         reviewQuestionRepository.deleteAllByReviewTask_IdIn(taskIds);
     }
 


### PR DESCRIPTION
## #️⃣ 기능 설명
> 상동

## 🛠️ 작업 상세 내용
- [ ] 라이브러리(퀴즈) 부분 api완성
## 📸 스크린샷 (선택)

## 💬 기타(공유사항 to 리뷰어)
crud 테스트를 부탁드립니다.
라이브러리에 값을 몇개 넣어주면 퀴즈를 할 수 있습니다. 
세션을 만들면 내가 퀴즈를 풀지않은 내 라이브러리 단어가 퀴즈화 되면서 퀴즈세션이 시작되고 제출할때마다 채점과 동시에 다음문제가 반환됩니다. 
그렇게 모든문제를 다 풀고 퀴즈 결과를 조회하면 퀴즈 결과를 볼수 있고 이때 재도전을 하면 내가 틀린문제만 모아서 퀴즈세션을 만들어줍니다. 
중간에 나갈수 있는 api와 나갔다 들어오면 퀴즈가 처음부터 다시 시작됩니다. 테이블 컬럼이 바뀌었기(몇개 삭제) 때문에 aplication.yml에서 하이버네이트 설정을 auto: update에서 auto :create로 바꿔주시면 정상적인 실행이 가능합니다. 궁금하신 부분은 저에게 물어보시면 시간되는대로 바로 답변하겠습니다.


추후 할것
오류 수정,최적화,퀴즈문제 방식(지금은 더미 데이터인데 , ai로 문제 돌릴지 아니면 전체 library데이터에서 문제를 랜덤메서드로 만들지 고민 중)