### PR TITLE
♻️ [Refactor] 쿠키로 내려주도록 수정

### DIFF
--- a/src/main/java/verbly/spring/domain/auth/controller/AuthRestController.java
+++ b/src/main/java/verbly/spring/domain/auth/controller/AuthRestController.java
@@ -47,35 +47,18 @@ public class AuthRestController {
     )
 //    public ApiResponse<AuthResponseDTO.ReissueTokenResponseDTO> reissueAccessToken(HttpServletRequest request) {
 //        String refreshToken = JwtTokenProvider.resolveToken(request); // Authorization 헤더에서 Bearer 토큰을 추출
-//    public void reissueAccessToken(HttpServletRequest request, HttpServletResponse response) {
-    public ApiResponse<AuthResponseDTO.ReissueTokenResponseDTO> reissueAccessToken(HttpServletRequest request, HttpServletResponse response) {
+    public void reissueAccessToken(HttpServletRequest request, HttpServletResponse response) {
+//    public ApiResponse<AuthResponseDTO.ReissueTokenResponseDTO> reissueAccessToken(HttpServletRequest request, HttpServletResponse response) {
 
         String refreshToken = jwtTokenProvider.resolveRefreshToken(request);
         if (!StringUtils.hasText(refreshToken) || !jwtTokenProvider.isRefreshToken(refreshToken)) { // refreshToken == null은 !StringUtils.hasText(refreshToken)로 체크 가능
             throw new AuthHandler(ErrorStatus.INVALID_JWT_REFRESH_TOKEN); // TOKEN4002
         }
 
-        AuthResponseDTO.ReissueTokenResponseDTO tokens = authCommandService.reissue(refreshToken);
+        authCommandService.reissue(response, refreshToken);
 
-        // 어세스 토큰 재발급
-        addCookie(response, "accessToken", tokens.getAccessToken(), true, 60 * 60 * 4); // 4시간
-
+//        return ApiResponse.onSuccess(tokens); // 테스트용
         // 응답 바디 없이 204 No Content
-//        response.setStatus(HttpServletResponse.SC_NO_CONTENT);
-
-        return ApiResponse.onSuccess(tokens); // 테스트용
-    }
-
-    private void addCookie(HttpServletResponse response, String name, String value, boolean httpOnly, int maxAgeInSeconds) {
-        ResponseCookie cookie = ResponseCookie.from(name, value)
-                .httpOnly(httpOnly)
-                .secure(true)
-                .path("/")
-                .domain("verbly.site")
-                .maxAge(maxAgeInSeconds)
-                .sameSite("Lax")
-                .build();
-
-        response.addHeader("Set-Cookie", cookie.toString());
+        response.setStatus(HttpServletResponse.SC_NO_CONTENT);
     }
 }

--- a/src/main/java/verbly/spring/domain/auth/service/AuthCommandService.java
+++ b/src/main/java/verbly/spring/domain/auth/service/AuthCommandService.java
@@ -5,5 +5,5 @@ import verbly.spring.domain.auth.dto.response.AuthResponseDTO;
 
 public interface AuthCommandService {
     void logout(HttpServletResponse response, Long userId);
-    AuthResponseDTO.ReissueTokenResponseDTO reissue(String refreshToken);
+    AuthResponseDTO.ReissueTokenResponseDTO reissue(HttpServletResponse response, String refreshToken);
 }

--- a/src/main/java/verbly/spring/domain/auth/service/AuthCommandServiceImpl.java
+++ b/src/main/java/verbly/spring/domain/auth/service/AuthCommandServiceImpl.java
@@ -29,27 +29,29 @@ public class AuthCommandServiceImpl implements AuthCommandService {
                 .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
 
         // JWT를 로컬(localStorage, 쿠키 등)에서 직접 제거해야 로그아웃
-        ResponseCookie deleteAccessTokenCookie = ResponseCookie.from("accessToken", "")
-                .httpOnly(true)
-                .secure(true)
-                .path("/")
-                .domain("verbly.site")
-                .maxAge(0)
-                .sameSite("Lax")
-                .build();
+        clearCookie(response, "accessToken", "", true, 0);
+//        ResponseCookie deleteAccessTokenCookie = ResponseCookie.from("accessToken", "")
+//                .httpOnly(true)
+//                .secure(true)
+//                .path("/")
+//                .domain("localhost") // www.verbly.kr
+//                .maxAge(0)
+//                .sameSite("Lax")
+//                .build();
 
         // refreshToken 쿠키 삭제 (즉시 만료 설정)
-        ResponseCookie deleteRefreshTokenCookie = ResponseCookie.from("refreshToken", "")
-                .httpOnly(true)
-                .secure(true) // HTTPS 환경이라면 true
-                .path("/")
-                .domain("verbly.site") // 운영 도메인과 맞춰서 설정
-                .maxAge(0) // 즉시 만료
-                .sameSite("Lax")
-                .build();
+        clearCookie(response, "refreshToken", "", true, 0);
+//        ResponseCookie deleteRefreshTokenCookie = ResponseCookie.from("refreshToken", "")
+//                .httpOnly(true)
+//                .secure(true) // HTTPS 환경이라면 true
+//                .path("/")
+//                .domain("localhost") // www.verbly.kr
+//                .maxAge(0) // 즉시 만료
+//                .sameSite("Lax")
+//                .build();
 
-        response.addHeader("Set-Cookie", deleteAccessTokenCookie.toString());
-        response.addHeader("Set-Cookie", deleteRefreshTokenCookie.toString());
+//        response.addHeader("Set-Cookie", deleteAccessTokenCookie.toString());
+//        response.addHeader("Set-Cookie", deleteRefreshTokenCookie.toString());
 //        response.addHeader("Set-Cookie", deleteCsrfCookie.toString());
 
         log.info("유저 {} 로그아웃 처리 및 JWT 쿠키 삭제 완료", user.getId());
@@ -86,5 +88,19 @@ public class AuthCommandServiceImpl implements AuthCommandService {
 
         // 5. DTO 변환은 컨버터에 위임
         return AuthConverter.toReissueTokenResponseDTO(newAccessToken);
+    }
+
+    private void clearCookie(HttpServletResponse response, String name, String value, boolean httpOnly, int maxAgeInSeconds) {
+        ResponseCookie deleteTokenCookie = ResponseCookie.from(name, value)
+                .httpOnly(httpOnly)
+                .secure(true)
+                .path("/")
+                .domain("localhost") // www.verbly.kr
+                .maxAge(maxAgeInSeconds)
+                .sameSite("Lax")
+                .build();
+
+        response.addHeader("Set-Cookie", deleteTokenCookie.toString());
+        log.info("쿠키 삭제 완료");
     }
 }

--- a/src/main/java/verbly/spring/domain/auth/service/AuthCommandServiceImpl.java
+++ b/src/main/java/verbly/spring/domain/auth/service/AuthCommandServiceImpl.java
@@ -30,29 +30,9 @@ public class AuthCommandServiceImpl implements AuthCommandService {
 
         // JWT를 로컬(localStorage, 쿠키 등)에서 직접 제거해야 로그아웃
         clearCookie(response, "accessToken", "", true, 0);
-//        ResponseCookie deleteAccessTokenCookie = ResponseCookie.from("accessToken", "")
-//                .httpOnly(true)
-//                .secure(true)
-//                .path("/")
-//                .domain("localhost") // www.verbly.kr
-//                .maxAge(0)
-//                .sameSite("Lax")
-//                .build();
 
         // refreshToken 쿠키 삭제 (즉시 만료 설정)
         clearCookie(response, "refreshToken", "", true, 0);
-//        ResponseCookie deleteRefreshTokenCookie = ResponseCookie.from("refreshToken", "")
-//                .httpOnly(true)
-//                .secure(true) // HTTPS 환경이라면 true
-//                .path("/")
-//                .domain("localhost") // www.verbly.kr
-//                .maxAge(0) // 즉시 만료
-//                .sameSite("Lax")
-//                .build();
-
-//        response.addHeader("Set-Cookie", deleteAccessTokenCookie.toString());
-//        response.addHeader("Set-Cookie", deleteRefreshTokenCookie.toString());
-//        response.addHeader("Set-Cookie", deleteCsrfCookie.toString());
 
         log.info("유저 {} 로그아웃 처리 및 JWT 쿠키 삭제 완료", user.getId());
     }

--- a/src/main/java/verbly/spring/domain/auth/service/AuthCommandServiceImpl.java
+++ b/src/main/java/verbly/spring/domain/auth/service/AuthCommandServiceImpl.java
@@ -29,10 +29,10 @@ public class AuthCommandServiceImpl implements AuthCommandService {
                 .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
 
         // JWT를 로컬(localStorage, 쿠키 등)에서 직접 제거해야 로그아웃
-        clearCookie(response, "accessToken", "", true, 0);
+        clearCookie(response, "accessToken", "", false, 0);
 
         // refreshToken 쿠키 삭제 (즉시 만료 설정)
-        clearCookie(response, "refreshToken", "", true, 0);
+        clearCookie(response, "refreshToken", "", false, 0);
 
         log.info("유저 {} 로그아웃 처리 및 JWT 쿠키 삭제 완료", user.getId());
     }
@@ -73,7 +73,7 @@ public class AuthCommandServiceImpl implements AuthCommandService {
     private void clearCookie(HttpServletResponse response, String name, String value, boolean httpOnly, int maxAgeInSeconds) {
         ResponseCookie deleteTokenCookie = ResponseCookie.from(name, value)
                 .httpOnly(httpOnly)
-                .secure(true)
+                .secure(false)
                 .path("/")
                 .domain("localhost") // www.verbly.kr
                 .maxAge(maxAgeInSeconds)

--- a/src/main/java/verbly/spring/domain/auth/service/AuthCommandServiceImpl.java
+++ b/src/main/java/verbly/spring/domain/auth/service/AuthCommandServiceImpl.java
@@ -38,7 +38,7 @@ public class AuthCommandServiceImpl implements AuthCommandService {
     }
 
     @Override
-    public AuthResponseDTO.ReissueTokenResponseDTO reissue(String refreshToken) {
+    public AuthResponseDTO.ReissueTokenResponseDTO reissue(HttpServletResponse response, String refreshToken) {
         // 1. RefreshToken 유효성 검사 (서명 및 토큰 타입까지 확인)
         if (!jwtTokenProvider.isRefreshToken(refreshToken)) {
             throw new AuthHandler(ErrorStatus.INVALID_JWT_REFRESH_TOKEN);
@@ -66,8 +66,23 @@ public class AuthCommandServiceImpl implements AuthCommandService {
                 )
         );
 
+        addCookie(response, "accessToken", newAccessToken, true, 60 * 60 * 4); // 4시간
+
         // 5. DTO 변환은 컨버터에 위임
         return AuthConverter.toReissueTokenResponseDTO(newAccessToken);
+    }
+
+    private void addCookie(HttpServletResponse response, String name, String value, boolean httpOnly, int maxAgeInSeconds) {
+        ResponseCookie cookie = ResponseCookie.from(name, value)
+                .httpOnly(httpOnly)
+                .secure(false) // 운영환경에서는 true (HTTPS)
+                .path("/")
+                .domain("localhost") // www.verbly.kr
+                .maxAge(maxAgeInSeconds)
+                .sameSite("Lax")
+                .build();
+
+        response.addHeader("Set-Cookie", cookie.toString());
     }
 
     private void clearCookie(HttpServletResponse response, String name, String value, boolean httpOnly, int maxAgeInSeconds) {

--- a/src/main/java/verbly/spring/global/security/config/SecurityConfig.java
+++ b/src/main/java/verbly/spring/global/security/config/SecurityConfig.java
@@ -41,13 +41,14 @@ public class SecurityConfig {
 
         // 버블리 프론트, 백엔드 로컬, 운영 도메인 등 실제 사용하는 도메인 입력
         config.setAllowedOrigins(List.of(
-                "https://www.verbly.site", // 프론트 도메인
-                "https://api.verbly.site", // 백엔드 도메인
-                "http://3.36.90.173:3000",
-                "http://3.36.90.173:8080",
-                "http://localhost:3000", // 로컬 프론트
-                "http://localhost:8080", // 로컬 백엔드
-                "http://localhost:5173" // 로컬 프론트
+                "https://www.verbly.kr", // 프론트 도메인
+                "https://api.verbly.kr", // 백엔드 도메인
+                "https://3.35.202.0", // https로 IP 배포
+//                "http://3.35.202.0:3000",
+                "http://3.35.202.0:8080",
+//                "http://localhost:3000", // 로컬 프론트
+                "http://localhost:5173",
+                "http://localhost:8080" // 로컬 백엔드
         ));
         config.setAllowedHeaders(List.of("*"));
         config.setExposedHeaders(List.of("Authorization"));  // JWT 토큰 읽기 허용

--- a/src/main/java/verbly/spring/global/security/oauth/handler/OAuth2FailureHandler.java
+++ b/src/main/java/verbly/spring/global/security/oauth/handler/OAuth2FailureHandler.java
@@ -40,7 +40,7 @@ public class OAuth2FailureHandler implements AuthenticationFailureHandler {
     private void addCookie(HttpServletResponse response, String name, String value, boolean httpOnly, int maxAgeInSeconds) {
         ResponseCookie cookie = ResponseCookie.from(name, value)
                 .httpOnly(httpOnly)
-                .secure(true) // 운영환경 HTTPS에서는 true로 유지
+                .secure(false) // 운영환경 HTTPS에서는 true로 유지
                 .path("/")
                 .domain("localhost") // www.verbly.kr
                 .maxAge(maxAgeInSeconds)

--- a/src/main/java/verbly/spring/global/security/oauth/handler/OAuth2FailureHandler.java
+++ b/src/main/java/verbly/spring/global/security/oauth/handler/OAuth2FailureHandler.java
@@ -19,11 +19,11 @@ public class OAuth2FailureHandler implements AuthenticationFailureHandler {
         log.error("❌ OAuth2 로그인 실패: {}", exception.getMessage());
 
         // JSON 응답 방식
-        response.setContentType("application/json;charset=UTF-8");
-        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-        response.getWriter().write("{\"success\": false, \"message\": \"" + exception.getMessage() + "\"}");
+//        response.setContentType("application/json;charset=UTF-8");
+//        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+//        response.getWriter().write("{\"success\": false, \"message\": \"" + exception.getMessage() + "\"}");
 
-        /*
+        /**/
         // 쿠키로 프론트에게 내려주기
         // 1. 실패 상태 쿠키 설정 (HttpOnly false → JS에서 읽음)
         addCookie(response, "isSuccess", "false", false, 60);
@@ -33,24 +33,16 @@ public class OAuth2FailureHandler implements AuthenticationFailureHandler {
         clearJsessionCookie(response);
 
         // 2. 실패용 브릿지 페이지로 리다이렉트
-        response.sendRedirect("https://www.verbly.site/oauth-redirect");
-        */
+        response.sendRedirect("http://localhost:5173/login/callback"); // https://www.verbly.kr/login/callback
 
     }
 
     private void addCookie(HttpServletResponse response, String name, String value, boolean httpOnly, int maxAgeInSeconds) {
-//        Cookie cookie = new Cookie(name, value);
-//        cookie.setHttpOnly(httpOnly);
-//        cookie.setSecure(true); // 운영환경 HTTPS에서는 true로 유지
-//        cookie.setPath("/");
-//        cookie.setDomain("verbly.site");
-//        cookie.setMaxAge(maxAgeInSeconds);
-//        response.addCookie(cookie);
         ResponseCookie cookie = ResponseCookie.from(name, value)
                 .httpOnly(httpOnly)
-                .secure(true)
+                .secure(true) // 운영환경 HTTPS에서는 true로 유지
                 .path("/")
-                .domain("verbly.site")
+                .domain("localhost") // www.verbly.kr
                 .maxAge(maxAgeInSeconds)
                 .sameSite("Lax")
                 .build();

--- a/src/main/java/verbly/spring/global/security/oauth/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/verbly/spring/global/security/oauth/handler/OAuth2SuccessHandler.java
@@ -58,7 +58,7 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
                 .orElse("default_profile_url");
         String email = Optional.ofNullable(user.getEmail()).orElse("");
 
-        /**/
+        /*
         // JSON 응답 방식 (SPA 등 API 호출용)
         AuthResponseDTO.LoginResultDTO result = AuthResponseDTO.LoginResultDTO.builder()
                 .accessToken(accessToken)
@@ -81,13 +81,13 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
         response.setContentType("application/json;charset=UTF-8");
         response.setStatus(HttpServletResponse.SC_OK);
         response.getWriter().write(objectMapper.writeValueAsString(apiResponse));
+        */
 
-
-        /*
+        /**/
         // 쿠키로 프론트에게 내려주기
-        boolean isOnboardingCompleted = user.getStatus() == UserStatus.ONBOARDING;
+        boolean isOnboardingCompleted = user.getStatus() == UserStatus.ACTIVE; // ACTIVE = 소셜 가입 완료, 온보딩 전
         SuccessStatus status = isOnboardingCompleted
-                ? SuccessStatus.USER_ALREADY_ONBOARDING_COMPLETED
+                ? SuccessStatus.USER_ALREADY_LOGIN
                 : SuccessStatus.USER_NEEDS_ONBOARDING;
 
         // 1. 민감 정보: HttpOnly + Secure 쿠키
@@ -108,8 +108,8 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
         clearJsessionCookie(response);
 
         // 3. 리다이렉트 (브릿지 페이지)
-        response.sendRedirect("https://www.verbly.site/oauth-redirect");
-        */
+        response.sendRedirect("http://localhost:5173/login/callback"); // https://www.verbly.kr/login/callback
+
     }
 
     private void addCookie(HttpServletResponse response, String name, String value, boolean httpOnly, int maxAgeInSeconds) {
@@ -117,7 +117,7 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
                 .httpOnly(httpOnly)
                 .secure(true) // 운영환경에서는 true (HTTPS)
                 .path("/")
-                .domain("verbly.site")
+                .domain("localhost") // www.verbly.kr
                 .maxAge(maxAgeInSeconds)
                 .sameSite("Lax")
                 .build();

--- a/src/main/java/verbly/spring/global/security/oauth/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/verbly/spring/global/security/oauth/handler/OAuth2SuccessHandler.java
@@ -95,9 +95,9 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
         addCookie(response, "refreshToken", refreshToken, true, 60 * 60 * 24 * 7); // 7일
         addCookie(response, "userId", String.valueOf(user.getId()), true, 60 * 60 * 4);
         addCookie(response, "provider", user.getProvider().toString(), false, 60 * 60 * 4);
-        addCookie(response, "nickname", nickname, false, 60 * 60 * 4);
-        addCookie(response, "profileImage", profileImageUrl, false, 60 * 60 * 4);
-        addCookie(response, "email", email, false, 60 * 60 * 4);
+        addCookie(response, "nickname", URLEncoder.encode(nickname, StandardCharsets.UTF_8), false, 60 * 60 * 4);
+        addCookie(response, "profileImage", URLEncoder.encode(profileImageUrl, StandardCharsets.UTF_8), false, 60 * 60 * 4);
+        addCookie(response, "email", URLEncoder.encode(email, StandardCharsets.UTF_8), false, 60 * 60 * 4);
         addCookie(response, "userStatus", String.valueOf(user.getStatus()), false, 60 * 60 * 4);
 
         // 2. 상태 정보: HttpOnly = false (JS에서 읽게)

--- a/src/main/java/verbly/spring/global/security/oauth/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/verbly/spring/global/security/oauth/handler/OAuth2SuccessHandler.java
@@ -115,7 +115,7 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
     private void addCookie(HttpServletResponse response, String name, String value, boolean httpOnly, int maxAgeInSeconds) {
         ResponseCookie cookie = ResponseCookie.from(name, value)
                 .httpOnly(httpOnly)
-                .secure(true) // 운영환경에서는 true (HTTPS)
+                .secure(false) // 운영환경에서는 true (HTTPS)
                 .path("/")
                 .domain("localhost") // www.verbly.kr
                 .maxAge(maxAgeInSeconds)
@@ -128,7 +128,7 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
     private void clearJsessionCookie(HttpServletResponse response) {
         ResponseCookie deleteJsessionCookie = ResponseCookie.from("JSESSIONID", "")
                 .httpOnly(true)
-                .secure(true)
+                .secure(false)
                 .path("/")
                 .maxAge(0) // 쿠키 즉시 만료
                 .build();


### PR DESCRIPTION
## #️⃣ 기능 설명
> 소셜로그인 성공/실패 핸들러, 로그아웃, 토큰 재발급 수정

## 🛠️ 작업 상세 내용
- [x] 프론트 로컬 개발 환경에 맞춰 .domain("localhost")로 내려줌
- [x] 프론트 로컬 환경에 맞춰 HTTP에 맞는 .secure(false)로 내려줌
- [x] 소셜 로그인 후 http://localhost:5173/login/callback로 리다이렉트 시킴
- [x] 토큰 재발급 컨트롤러의 addCookie를 서비스로 옮겨 책임 분리

## 📸 스크린샷 (선택)

## 💬 기타(공유사항 to 리뷰어)
개발자모드에서 쿠키 확인 가능. 유저 정보 조회-토큰 재발급-로그아웃 등 테스트하시면 됩니다.

한글이 들어가면 에러나서 인코딩함. 프론트에서 읽을 때는 `decodeURIComponent(cookieValue)`로 복원하면 됨
Access Token은 서버에 저장하지 않으므로 서버가 삭제할 수 없음. 클라이언트 저장소에서 제거해야 함

프론트 배포 후 
- .secure(true)로 수정해야 함
- .domain("www.verbly.kr")로 수정해야 함
- 성공/실패 핸들러도 https://www.verbly.kr/login/callback로 리다이렉트 해야 함