### PR TITLE
✨ [Feat] 회원 정보 조회 API 응답에 유저 팔로잉 수 조회 기능 추가

### DIFF
--- a/src/main/java/verbly/spring/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/verbly/spring/domain/follow/repository/FollowRepository.java
@@ -1,4 +1,4 @@
-package verbly.spring.domain.follow.repo;
+package verbly.spring.domain.follow.repository;
 
 import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.domain.Pageable;
@@ -26,8 +26,8 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
         ORDER BY FUNCTION('rand')
      """)
     List<User> findRandomUser(@Param("followerId") Long followerId, Pageable pageable);
-
     void deleteByFollowerIdAndFolloweeId(Long followerId, Long followeeId);
-
     boolean existsFollowByFollowerIdAndFolloweeId(Long followerId, Long followeeId);
+    long countByFollowerId(Long followerId); // 내가 팔로우한 수
+    long countByFolloweeId(Long followeeId); // 나를 팔로우한 수 // 추후 확장할 수도
 }

--- a/src/main/java/verbly/spring/domain/follow/service/FollowService.java
+++ b/src/main/java/verbly/spring/domain/follow/service/FollowService.java
@@ -6,7 +6,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import verbly.spring.domain.follow.entity.Follow;
 import verbly.spring.domain.follow.exception.FollowHandler;
-import verbly.spring.domain.follow.repo.FollowRepository;
+import verbly.spring.domain.follow.repository.FollowRepository;
 import verbly.spring.domain.user.dto.response.UserResponseDTO;
 import verbly.spring.domain.user.entity.User;
 import verbly.spring.domain.user.exception.UserHandler;

--- a/src/main/java/verbly/spring/domain/user/converter/UserConverter.java
+++ b/src/main/java/verbly/spring/domain/user/converter/UserConverter.java
@@ -29,7 +29,7 @@ public class UserConverter {
                 .build();
     }
 
-    public static UserResponseDTO.UserInfoDTO toUserInfoDTO(User user, long totalPosts, long correctionsGiven, long correctionsReceived) {
+    public static UserResponseDTO.UserInfoDTO toUserInfoDTO(User user, long totalPosts, long correctionsGiven, long correctionsReceived, long followingCount) {
         String profileImageUrl = Optional.ofNullable(user.getProfileImage())
                 .map(ProfileImage::getImageUrl)
                 .orElse("default_profile_url");
@@ -46,7 +46,7 @@ public class UserConverter {
                 .streakDays(user.getStats().getStreakDays())
                 .point(user.getStats().getPoint())
                 .level(user.getStats().getLevel().getValue())
-//                .followCount(user.getFollowCount())
+                .followCount(followingCount)
                 .totalPosts(totalPosts)
                 .correctionsGiven(correctionsGiven)
                 .correctionsReceived(correctionsReceived)

--- a/src/main/java/verbly/spring/domain/user/dto/response/UserResponseDTO.java
+++ b/src/main/java/verbly/spring/domain/user/dto/response/UserResponseDTO.java
@@ -39,7 +39,7 @@ public class UserResponseDTO {
         private long point;
         private int level;
 
-//        private long followCount;
+        private long followCount;
         private long totalPosts;
         private long correctionsGiven; // 외국인에게만 뜨는 도움 준 수
         private long correctionsReceived; // 한국인에게만 뜨는 도움 받은 글

--- a/src/main/java/verbly/spring/domain/user/service/UserQueryServiceImpl.java
+++ b/src/main/java/verbly/spring/domain/user/service/UserQueryServiceImpl.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import verbly.spring.domain.correction.repository.CorrectionFeedbackRepository;
 import verbly.spring.domain.correction.repository.CorrectionRepository;
+import verbly.spring.domain.follow.repository.FollowRepository;
 import verbly.spring.domain.post.repository.PostRepository;
 import verbly.spring.domain.user.converter.UserConverter;
 import verbly.spring.domain.user.dto.response.UserResponseDTO;
@@ -22,6 +23,7 @@ public class UserQueryServiceImpl implements UserQueryService {
     private final PostRepository postRepository;
     private final CorrectionRepository correctionRepository;
     private final CorrectionFeedbackRepository correctionFeedbackRepository;
+    private final FollowRepository followRepository;
     private final JwtTokenProvider jwtTokenProvider;
     private final ProfileValidator profileValidator;
 
@@ -37,7 +39,8 @@ public class UserQueryServiceImpl implements UserQueryService {
         long totalPosts = postRepository.countByAuthor_Id(user.getId());
         long correctionsGiven = correctionFeedbackRepository.countByCorrector_Id(user.getId());
         long correctionsReceived = correctionRepository.countByPost_Author_Id(user.getId());
+        long followingCount = followRepository.countByFollowerId(user.getId());
 
-        return UserConverter.toUserInfoDTO(user, totalPosts, correctionsGiven, correctionsReceived); // 정보 조회에 성공하면, 우리가 정의한 Response DTO인 UserInfoDTO 로 반환
+        return UserConverter.toUserInfoDTO(user, totalPosts, correctionsGiven, correctionsReceived, followingCount); // 정보 조회에 성공하면, 우리가 정의한 Response DTO인 UserInfoDTO 로 반환
     }
 }


### PR DESCRIPTION
## #️⃣ 기능 설명
> 상동

## 🛠️ 작업 상세 내용
- [x] 회원 정보 조회 API 응답에 유저 팔로잉 수 조회 기능 추가

## 📸 스크린샷 (선택)
<img width="355" height="425" alt="image" src="https://github.com/user-attachments/assets/32274f59-1ba9-4161-900e-bb5af5e09ee6" />

## 💬 기타(공유사항 to 리뷰어)
팔로우할 때마다 회원 정보 조회 API 사용하면 팔로우 숫자 늘어남
팔로우 삭제하면 그에 따라 회원 정보 조회 API 사용하면 숫자 줄어드는 것 확인하시면 됩니다!