### PR TITLE
♻️ [Refactor] 쿠키 생성/삭제 로직 CookieUtils로 공통화

### DIFF
--- a/src/main/java/verbly/spring/domain/auth/service/AuthCommandServiceImpl.java
+++ b/src/main/java/verbly/spring/domain/auth/service/AuthCommandServiceImpl.java
@@ -13,6 +13,7 @@ import verbly.spring.domain.user.entity.User;
 import verbly.spring.domain.user.exception.UserHandler;
 import verbly.spring.domain.user.repository.UserRepository;
 import verbly.spring.global.common.code.ErrorStatus;
+import verbly.spring.global.common.utils.CookieUtils;
 import verbly.spring.global.security.auth.CustomUserDetails;
 import verbly.spring.global.security.jwt.JwtTokenProvider;
 
@@ -22,6 +23,7 @@ import verbly.spring.global.security.jwt.JwtTokenProvider;
 public class AuthCommandServiceImpl implements AuthCommandService {
     private final UserRepository userRepository;
     private final JwtTokenProvider jwtTokenProvider;
+    private final CookieUtils cookieUtils;
 
     @Override
     public void logout(HttpServletResponse response, Long userId) {
@@ -29,10 +31,10 @@ public class AuthCommandServiceImpl implements AuthCommandService {
                 .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
 
         // JWT를 로컬(localStorage, 쿠키 등)에서 직접 제거해야 로그아웃
-        clearCookie(response, "accessToken", "", false, 0);
+        cookieUtils.clearCookie(response, "accessToken", "", false);
 
         // refreshToken 쿠키 삭제 (즉시 만료 설정)
-        clearCookie(response, "refreshToken", "", false, 0);
+        cookieUtils.clearCookie(response, "refreshToken", "", false);
 
         log.info("유저 {} 로그아웃 처리 및 JWT 쿠키 삭제 완료", user.getId());
     }
@@ -66,36 +68,9 @@ public class AuthCommandServiceImpl implements AuthCommandService {
                 )
         );
 
-        addCookie(response, "accessToken", newAccessToken, true, 60 * 60 * 4); // 4시간
+        cookieUtils.addCookie(response, "accessToken", newAccessToken, true, 60 * 60 * 4); // 4시간
 
         // 5. DTO 변환은 컨버터에 위임
         return AuthConverter.toReissueTokenResponseDTO(newAccessToken);
-    }
-
-    private void addCookie(HttpServletResponse response, String name, String value, boolean httpOnly, int maxAgeInSeconds) {
-        ResponseCookie cookie = ResponseCookie.from(name, value)
-                .httpOnly(httpOnly)
-                .secure(false) // 운영환경에서는 true (HTTPS)
-                .path("/")
-                .domain("localhost") // www.verbly.kr
-                .maxAge(maxAgeInSeconds)
-                .sameSite("Lax")
-                .build();
-
-        response.addHeader("Set-Cookie", cookie.toString());
-    }
-
-    private void clearCookie(HttpServletResponse response, String name, String value, boolean httpOnly, int maxAgeInSeconds) {
-        ResponseCookie deleteTokenCookie = ResponseCookie.from(name, value)
-                .httpOnly(httpOnly)
-                .secure(false)
-                .path("/")
-                .domain("localhost") // www.verbly.kr
-                .maxAge(maxAgeInSeconds)
-                .sameSite("Lax")
-                .build();
-
-        response.addHeader("Set-Cookie", deleteTokenCookie.toString());
-        log.info("쿠키 삭제 완료");
     }
 }

--- a/src/main/java/verbly/spring/global/common/utils/CookieUtils.java
+++ b/src/main/java/verbly/spring/global/common/utils/CookieUtils.java
@@ -1,0 +1,49 @@
+package verbly.spring.global.common.utils;
+
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class CookieUtils {
+    public void addCookie(HttpServletResponse response, String name, String value, boolean httpOnly, int maxAgeInSeconds) {
+        ResponseCookie cookie = ResponseCookie.from(name, value)
+                .httpOnly(httpOnly)
+                .secure(false) // 운영환경에서는 true (HTTPS)
+                .path("/")
+                .domain("localhost") // www.verbly.kr
+                .maxAge(maxAgeInSeconds)
+                .sameSite("Lax")
+                .build();
+
+        response.addHeader("Set-Cookie", cookie.toString());
+        log.info("쿠키 생성 완료: {}", name);
+    }
+
+    public void clearCookie(HttpServletResponse response, String name, String value, boolean httpOnly) {
+        ResponseCookie deleteTokenCookie = ResponseCookie.from(name, value)
+                .httpOnly(httpOnly)
+                .secure(false)
+                .path("/")
+                .domain("localhost") // www.verbly.kr
+                .maxAge(0)
+                .sameSite("Lax")
+                .build();
+
+        response.addHeader("Set-Cookie", deleteTokenCookie.toString());
+        log.info("쿠키 삭제 완료{}", name);
+    }
+
+    public void clearJsessionCookie(HttpServletResponse response) {
+        ResponseCookie deleteJsessionCookie = ResponseCookie.from("JSESSIONID", "")
+                .httpOnly(true)
+                .secure(false)
+                .path("/")
+                .maxAge(0) // 쿠키 즉시 만료
+                .build();
+        response.addHeader("Set-Cookie", deleteJsessionCookie.toString());
+        log.info("JSESSIONID 쿠키 삭제 완료");
+    }
+}

--- a/src/main/java/verbly/spring/global/security/oauth/handler/OAuth2FailureHandler.java
+++ b/src/main/java/verbly/spring/global/security/oauth/handler/OAuth2FailureHandler.java
@@ -3,17 +3,22 @@ package verbly.spring.global.security.oauth.handler;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.stereotype.Component;
+import verbly.spring.global.common.utils.CookieUtils;
 
 import java.io.IOException;
 
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class OAuth2FailureHandler implements AuthenticationFailureHandler {
+    private final CookieUtils cookieUtils;
+
     @Override
     public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
         log.error("❌ OAuth2 로그인 실패: {}", exception.getMessage());
@@ -26,38 +31,14 @@ public class OAuth2FailureHandler implements AuthenticationFailureHandler {
         /**/
         // 쿠키로 프론트에게 내려주기
         // 1. 실패 상태 쿠키 설정 (HttpOnly false → JS에서 읽음)
-        addCookie(response, "isSuccess", "false", false, 60);
-        addCookie(response, "code", "AUTH_FAILURE", false, 60);  // 필요 시 고유 코드로 변경 가능
-        addCookie(response, "message", java.net.URLEncoder.encode(exception.getMessage(), java.nio.charset.StandardCharsets.UTF_8), false, 60);
+        cookieUtils.addCookie(response, "isSuccess", "false", false, 60);
+        cookieUtils.addCookie(response, "code", "AUTH_FAILURE", false, 60);  // 필요 시 고유 코드로 변경 가능
+        cookieUtils.addCookie(response, "message", java.net.URLEncoder.encode(exception.getMessage(), java.nio.charset.StandardCharsets.UTF_8), false, 60);
 
-        clearJsessionCookie(response);
+        cookieUtils.clearJsessionCookie(response);
 
         // 2. 실패용 브릿지 페이지로 리다이렉트
         response.sendRedirect("http://localhost:5173/login/callback"); // https://www.verbly.kr/login/callback
 
-    }
-
-    private void addCookie(HttpServletResponse response, String name, String value, boolean httpOnly, int maxAgeInSeconds) {
-        ResponseCookie cookie = ResponseCookie.from(name, value)
-                .httpOnly(httpOnly)
-                .secure(false) // 운영환경 HTTPS에서는 true로 유지
-                .path("/")
-                .domain("localhost") // www.verbly.kr
-                .maxAge(maxAgeInSeconds)
-                .sameSite("Lax")
-                .build();
-
-        response.addHeader("Set-Cookie", cookie.toString());
-    }
-
-    private void clearJsessionCookie(HttpServletResponse response) {
-        ResponseCookie deleteJsessionCookie = ResponseCookie.from("JSESSIONID", "")
-                .httpOnly(true)
-                .secure(true)
-                .path("/")
-                .maxAge(0) // 쿠키 즉시 만료
-                .build();
-        response.addHeader("Set-Cookie", deleteJsessionCookie.toString());
-        log.info("JSESSIONID 쿠키 삭제 완료");
     }
 }

--- a/src/main/java/verbly/spring/global/security/oauth/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/verbly/spring/global/security/oauth/handler/OAuth2SuccessHandler.java
@@ -17,6 +17,7 @@ import verbly.spring.domain.user.entity.User;
 import verbly.spring.domain.user.enums.UserStatus;
 import verbly.spring.global.common.code.SuccessStatus;
 import verbly.spring.global.common.response.ApiResponse;
+import verbly.spring.global.common.utils.CookieUtils;
 import verbly.spring.global.security.auth.CustomOAuth2User;
 import verbly.spring.global.security.jwt.JwtTokenProvider;
 import org.springframework.stereotype.Component;
@@ -31,8 +32,8 @@ import java.util.Optional;
 @Component
 @RequiredArgsConstructor
 public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
-
     private final JwtTokenProvider jwtTokenProvider;
+    private final CookieUtils cookieUtils;
     private final ObjectMapper objectMapper;
 
     @Override
@@ -91,48 +92,23 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
                 : SuccessStatus.USER_NEEDS_ONBOARDING;
 
         // 1. 민감 정보: HttpOnly + Secure 쿠키
-        addCookie(response, "accessToken", accessToken, true, 60 * 60 * 4); // 4시간
-        addCookie(response, "refreshToken", refreshToken, true, 60 * 60 * 24 * 7); // 7일
-        addCookie(response, "userId", String.valueOf(user.getId()), true, 60 * 60 * 4);
-        addCookie(response, "provider", user.getProvider().toString(), false, 60 * 60 * 4);
-        addCookie(response, "nickname", URLEncoder.encode(nickname, StandardCharsets.UTF_8), false, 60 * 60 * 4);
-        addCookie(response, "profileImage", URLEncoder.encode(profileImageUrl, StandardCharsets.UTF_8), false, 60 * 60 * 4);
-        addCookie(response, "email", URLEncoder.encode(email, StandardCharsets.UTF_8), false, 60 * 60 * 4);
-        addCookie(response, "userStatus", String.valueOf(user.getStatus()), false, 60 * 60 * 4);
+        cookieUtils.addCookie(response, "accessToken", accessToken, true, 60 * 60 * 4); // 4시간
+        cookieUtils.addCookie(response, "refreshToken", refreshToken, true, 60 * 60 * 24 * 7); // 7일
+        cookieUtils.addCookie(response, "userId", String.valueOf(user.getId()), true, 60 * 60 * 4);
+        cookieUtils.addCookie(response, "provider", user.getProvider().toString(), false, 60 * 60 * 4);
+        cookieUtils.addCookie(response, "nickname", URLEncoder.encode(nickname, StandardCharsets.UTF_8), false, 60 * 60 * 4);
+        cookieUtils.addCookie(response, "profileImage", URLEncoder.encode(profileImageUrl, StandardCharsets.UTF_8), false, 60 * 60 * 4);
+        cookieUtils.addCookie(response, "email", URLEncoder.encode(email, StandardCharsets.UTF_8), false, 60 * 60 * 4);
+        cookieUtils.addCookie(response, "userStatus", String.valueOf(user.getStatus()), false, 60 * 60 * 4);
 
         // 2. 상태 정보: HttpOnly = false (JS에서 읽게)
-        addCookie(response, "isSuccess", "true", false, 60);
-        addCookie(response, "code", status.getCode(), false, 60);
-        addCookie(response, "message", URLEncoder.encode(status.getMessage(), StandardCharsets.UTF_8), false, 60);
+        cookieUtils.addCookie(response, "isSuccess", "true", false, 60);
+        cookieUtils.addCookie(response, "code", status.getCode(), false, 60);
+        cookieUtils.addCookie(response, "message", URLEncoder.encode(status.getMessage(), StandardCharsets.UTF_8), false, 60);
 
-        clearJsessionCookie(response);
+        cookieUtils.clearJsessionCookie(response);
 
         // 3. 리다이렉트 (브릿지 페이지)
         response.sendRedirect("http://localhost:5173/login/callback"); // https://www.verbly.kr/login/callback
-
-    }
-
-    private void addCookie(HttpServletResponse response, String name, String value, boolean httpOnly, int maxAgeInSeconds) {
-        ResponseCookie cookie = ResponseCookie.from(name, value)
-                .httpOnly(httpOnly)
-                .secure(false) // 운영환경에서는 true (HTTPS)
-                .path("/")
-                .domain("localhost") // www.verbly.kr
-                .maxAge(maxAgeInSeconds)
-                .sameSite("Lax")
-                .build();
-
-        response.addHeader("Set-Cookie", cookie.toString());
-    }
-
-    private void clearJsessionCookie(HttpServletResponse response) {
-        ResponseCookie deleteJsessionCookie = ResponseCookie.from("JSESSIONID", "")
-                .httpOnly(true)
-                .secure(false)
-                .path("/")
-                .maxAge(0) // 쿠키 즉시 만료
-                .build();
-        response.addHeader("Set-Cookie", deleteJsessionCookie.toString());
-        log.info("JSESSIONID 쿠키 삭제 완료");
     }
 }


### PR DESCRIPTION
## #️⃣ 기능 설명
> 상동

## 🛠️ 작업 상세 내용
- [x] 중복되던 Cookie 처리 로직을 CookieUtils로 공통화하여 책임 분리
- [x] 소셜로그인 성공/실패 핸들러에서 호출하던 쿠키 메소드 삭제
- [x] AuthCommandServiceImpl에서 호출하던 쿠키 메소드 삭제

## 📸 스크린샷 (선택)
<img width="1549" height="866" alt="image" src="https://github.com/user-attachments/assets/dc457c80-0233-4b32-91b4-77774e633ef6" />

## 💬 기타(공유사항 to 리뷰어)
개발자모드-Application에서 쿠키 확인 가능. 유저 정보 조회-토큰 재발급-로그아웃 등 테스트하시면 됩니다.

프론트 배포 후
- CookieUtils에서 .secure(true)로 수정해야 함
- CookieUtils에서 .domain("www.verbly.kr")로 수정해야 함
- 성공/실패 핸들러도 https://www.verbly.kr/login/callback으로 리다이렉트 해야 함