### PR TITLE
🔨 [Fix] 카카오/구글 기본 프로필에서 S3 이미지로 변경 시 500 오류 수정

### DIFF
--- a/src/main/java/verbly/spring/domain/user/service/UserCommandServiceImpl.java
+++ b/src/main/java/verbly/spring/domain/user/service/UserCommandServiceImpl.java
@@ -119,9 +119,11 @@ public class UserCommandServiceImpl implements UserCommandService {
         String profileImageUrl = s3Manager.uploadFile(s3Manager.generateUserKeyName(uuid), profileImage);
 
         if (user.getProfileImage() != null) {
-            // 기존 이미지의 키 추출 및 삭제
+            // 기존 URL이 S3일 때만 기존 이미지의 키 추출 및 삭제
             String oldKey = s3Manager.extractS3KeyFromUrl(user.getProfileImage().getImageUrl());
-            s3Manager.deleteFile(oldKey);
+            if (oldKey != null) {
+                s3Manager.deleteFile(oldKey);
+            }
 
             // update: 기존 엔티티에 새로운 URL만 set
             user.getProfileImage().updateImageUrl(profileImageUrl);

--- a/src/main/java/verbly/spring/global/common/aws/s3/AmazonS3Manager.java
+++ b/src/main/java/verbly/spring/global/common/aws/s3/AmazonS3Manager.java
@@ -43,7 +43,7 @@ public class AmazonS3Manager {
 
         String bucketUrlPrefix = "https://" + amazonConfig.getBucket() + ".s3." + amazonConfig.getRegion() + ".amazonaws.com/";
 
-        if (imageUrl.startsWith(bucketUrlPrefix)) {
+        if (!imageUrl.startsWith(bucketUrlPrefix)) {
             log.info("S3가 아닌 외부 프로필 URL이므로 삭제 대상에서 제외합니다. url={}", imageUrl);
             return null;
         } //else {

--- a/src/main/java/verbly/spring/global/common/aws/s3/AmazonS3Manager.java
+++ b/src/main/java/verbly/spring/global/common/aws/s3/AmazonS3Manager.java
@@ -37,13 +37,19 @@ public class AmazonS3Manager {
     }
 
     public String extractS3KeyFromUrl(String imageUrl) {
+        if (imageUrl == null || imageUrl.isBlank()) {
+            return null;
+        }
+
         String bucketUrlPrefix = "https://" + amazonConfig.getBucket() + ".s3." + amazonConfig.getRegion() + ".amazonaws.com/";
 
-        if (imageUrl != null && imageUrl.startsWith(bucketUrlPrefix)) {
-            return imageUrl.substring(bucketUrlPrefix.length());
-        } else {
-            throw new IllegalArgumentException("S3 URL에서 key를 추출할 수 없습니다: " + imageUrl);
-        }
+        if (imageUrl.startsWith(bucketUrlPrefix)) {
+            log.info("S3가 아닌 외부 프로필 URL이므로 삭제 대상에서 제외합니다. url={}", imageUrl);
+            return null;
+        } //else {
+//            throw new IllegalArgumentException("S3 URL에서 key를 추출할 수 없습니다: " + imageUrl);
+//        }
+        return imageUrl.substring(bucketUrlPrefix.length());
     }
 
     public void deleteFile(String keyName) {


### PR DESCRIPTION
## #️⃣ 기능 설명
> 소셜 로그인 유저의 기존 카카오/구글 프로필 이미지와 상관없이 프로필을 변경할 수 있도록 S3 연동 로직을 수정함(기존 이미지가 소셜 URL인 경우에도 500 에러 없이 안전하게 새 S3 이미지로 교체되도록)

## 🛠️ 작업 상세 내용
- [x] 기존 프로필 이미지 URL이 S3 URL일 때만 S3 삭제를 수행하도록 extractS3KeyFromUrl 및 호출부 로직 수정
- [x] 소셜 프로필 URL(카카오/구글)에서 S3 이미지로 변경 시 예외 없이 정상 동작하도록 updateProfileImage 보호 로직 추가
- [x]  프로필 이미지 변경 API에 대해 소셜 기본 이미지 → S3 이미지, S3 → S3 변경 시나리오를 포함한 테스트 수행

## 📸 스크린샷 (선택)
<img width="440" height="439" alt="image" src="https://github.com/user-attachments/assets/1f7c9ca8-432a-481d-ae7d-89eb348501cb" />

## 💬 기타(공유사항 to 리뷰어)
1. 처음 소셜로그인하면 해당 소셜의 이미지가 본인의 프로필 이미지가 됨.
2. 이 상태에서 PATCH [/api/user]로 프로필 이미지 변경 후 GET [/api/user/me]에서 보이는 프로필 이미지 링크 복사해서 탭에 입력하면 변경한 이미지 확인 가능
3. 또 다른 이미지로 수정하고 싶으면 2번 다시 하면 됨