### PR TITLE
✨[Feat] post 관련 테이블 삭제 매핑 및 correction 상세 첨삭 조회 추가

### DIFF
--- a/src/main/java/verbly/spring/domain/correction/controller/CorrectionController.java
+++ b/src/main/java/verbly/spring/domain/correction/controller/CorrectionController.java
@@ -15,6 +15,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import verbly.spring.domain.correction.dto.request.CorrectionRequestDTO;
+import verbly.spring.domain.correction.dto.response.CorrectionEditorResponseDTO;
 import verbly.spring.domain.correction.dto.response.CorrectionListResponseDTO;
 import verbly.spring.domain.correction.dto.response.CorrectionResponseDTO;
 import verbly.spring.domain.correction.enums.CorrectorType;
@@ -135,10 +136,10 @@ public class CorrectionController {
             description = "자신이 작성한 커렉션 상세 정보를 조회합니다."
     )
     @GetMapping("/{correctionId}")
-    public ResponseEntity<ApiResponse<CorrectionResponseDTO.MyCorrectionDto>> getCorrectionDetail(
+    public ResponseEntity<ApiResponse<CorrectionEditorResponseDTO.Detail>> getCorrectionDetail(
             @PathVariable Long correctionId
     ){
-        CorrectionResponseDTO.MyCorrectionDto result = correctionService.getCorrectionDetail(correctionId);
+        CorrectionEditorResponseDTO.Detail result = correctionService.getMyCorrectionDetailAsEditor(correctionId);
 
         return ResponseEntity
                 .status(SuccessStatus.CORRECTION_READ_SUCCESS.getHttpStatus())

--- a/src/main/java/verbly/spring/domain/correction/entity/Correction.java
+++ b/src/main/java/verbly/spring/domain/correction/entity/Correction.java
@@ -7,6 +7,9 @@ import verbly.spring.domain.post.entity.Post;
 import verbly.spring.domain.user.entity.User;
 import verbly.spring.global.common.entity.BaseEntity;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
@@ -29,6 +32,19 @@ public class Correction extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column
     private CorrectorType correctorType;
+
+    @OneToMany(mappedBy = "correction", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<CorrectionWord> words = new ArrayList<>();
+
+    @OneToMany(mappedBy = "correction", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<CorrectionFeedback> feedbacks = new ArrayList<>();
+
+    @OneToMany(mappedBy = "correction", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<CorrectionBookmark> bookmarks = new ArrayList<>();
+
 
     public void markAiAssistant() {
         this.corrector = null;

--- a/src/main/java/verbly/spring/domain/correction/repository/CorrectionFeedbackRepository.java
+++ b/src/main/java/verbly/spring/domain/correction/repository/CorrectionFeedbackRepository.java
@@ -3,6 +3,7 @@ package verbly.spring.domain.correction.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import verbly.spring.domain.correction.entity.CorrectionFeedback;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface CorrectionFeedbackRepository extends JpaRepository<CorrectionFeedback, Long> {
@@ -11,5 +12,5 @@ public interface CorrectionFeedbackRepository extends JpaRepository<CorrectionFe
     long countDistinctCorrectionByCorrectorId(Long correctorId);
     Optional<CorrectionFeedback> findTopByCorrectionIdOrderByCreatedAtDesc(Long correctionId);
     boolean existsByCorrectionId(Long correctionId);
-
+    List<CorrectionFeedback> findAllByCorrectionIdOrderByCreatedAtAsc(Long correctionId);
 }

--- a/src/main/java/verbly/spring/domain/correction/repository/CorrectionWordRepository.java
+++ b/src/main/java/verbly/spring/domain/correction/repository/CorrectionWordRepository.java
@@ -38,4 +38,5 @@ public interface CorrectionWordRepository extends JpaRepository<CorrectionWord, 
 
     boolean existsByCorrectionId(Long correctionId);
 
+    List<CorrectionWord> findByCorrectionIdOrderBySentenceIdxAscStartIdxAsc(Long correctionId);
 }

--- a/src/main/java/verbly/spring/domain/correction/service/CorrectionService.java
+++ b/src/main/java/verbly/spring/domain/correction/service/CorrectionService.java
@@ -5,11 +5,14 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import verbly.spring.domain.correction.converter.CorrectionConverter;
+import verbly.spring.domain.correction.converter.CorrectionEditorConverter;
 import verbly.spring.domain.correction.dto.request.CorrectionRequestDTO;
+import verbly.spring.domain.correction.dto.response.CorrectionEditorResponseDTO;
 import verbly.spring.domain.correction.dto.response.CorrectionListResponseDTO;
 import verbly.spring.domain.correction.dto.response.CorrectionResponseDTO;
 import verbly.spring.domain.correction.entity.Correction;
 import verbly.spring.domain.correction.entity.CorrectionBookmark;
+import verbly.spring.domain.correction.entity.CorrectionFeedback;
 import verbly.spring.domain.correction.entity.CorrectionWord;
 import verbly.spring.domain.correction.enums.CorrectorType;
 import verbly.spring.domain.correction.exception.CorrectionHandler;
@@ -293,6 +296,134 @@ public class CorrectionService {
         Long userId = SecurityUtils.getCurrentUserId();
 
         correctionBookmarkRepository.deleteByUserIdAndCorrectionId(userId, correctionId);
+    }
+
+    /**
+     * 첨삭 editer 상세 조회
+     */
+    @Transactional(readOnly = true)
+    public CorrectionEditorResponseDTO.Detail getMyCorrectionDetailAsEditor(Long correctionId) {
+        validateNativeAccess();
+
+        Long userId = SecurityUtils.getCurrentUserId();
+
+        Correction correction = findOwnedCorrectionDetailOrThrow(userId, correctionId);
+
+        List<CorrectionWord> wordEntities =
+                correctionWordRepository.findByCorrectionIdOrderBySentenceIdxAscStartIdxAsc(correctionId);
+
+        List<CorrectionEditorResponseDTO.Word> words = wordEntities.stream()
+                .map(w -> CorrectionEditorResponseDTO.Word.builder()
+                        .wordId(w.getId())
+                        .sentenceIdx(w.getSentenceIdx())
+                        .startIdx(w.getStartIdx())
+                        .endIdx(w.getEndIdx())
+                        .originalText(w.getOriginalText())
+                        .correctedText(w.getCorrectedText())
+                        .build())
+                .toList();
+
+        String postContent = correction.getPost().getContent();
+        List<CorrectionEditorResponseDTO.Sentence> sentences =
+                buildEditorSentences(postContent, wordEntities);
+
+        List<CorrectionEditorResponseDTO.Feedback> feedback = correctionFeedbackRepository
+                .findAllByCorrectionIdOrderByCreatedAtAsc(correctionId)
+                .stream()
+                .map(f -> CorrectionEditorResponseDTO.Feedback.builder()
+                        .feedbackId(f.getId())
+                        .sentenceIdx(f.getSentenceIdx())
+                        .correctorType(f.getCorrectorType())
+                        .correctorName(resolveCorrectorName(f))
+                        .content(f.getContent())
+                        .createdAt(f.getCreatedAt())
+                        .updatedAt(f.getUpdatedAt())
+                        .build())
+                .toList();
+
+        return CorrectionEditorResponseDTO.Detail.builder()
+                .correctionId(correction.getId())
+                .postId(correction.getPost().getId())
+                .status(correction.getPost().getStatus())
+                .sentences(sentences)
+                .words(words)
+                .feedback(feedback)
+                .build();
+    }
+
+
+    private String resolveCorrectorName(CorrectionFeedback f) {
+        if (f.getCorrectorType() == CorrectorType.AI_ASSISTANT) return "AI Assistant";
+        if (f.getCorrectorType() == CorrectorType.NATIVE_SPEAKER && f.getCorrector() != null) {
+            return f.getCorrector().getNickname();
+        }
+        return null;
+    }
+
+    private List<CorrectionEditorResponseDTO.Sentence> buildEditorSentences(
+            String postContent,
+            List<CorrectionWord> words
+    ) {
+        List<String> originals = CorrectionEditorConverter.splitSentences(postContent);
+
+        var grouped = words.stream()
+                .collect(java.util.stream.Collectors.groupingBy(
+                        CorrectionWord::getSentenceIdx,
+                        java.util.LinkedHashMap::new,
+                        java.util.stream.Collectors.toList()
+                ));
+
+        List<CorrectionEditorResponseDTO.Sentence> result = new java.util.ArrayList<>();
+
+        for (int sentenceIdx = 0; sentenceIdx < originals.size(); sentenceIdx++) {
+            String originalSentence = originals.get(sentenceIdx);
+
+            List<CorrectionWord> ws = grouped.getOrDefault(sentenceIdx, List.of());
+            ws = ws.stream()
+                    .sorted(java.util.Comparator
+                            .comparingInt(CorrectionWord::getStartIdx)
+                            .thenComparingInt(CorrectionWord::getEndIdx))
+                    .toList();
+
+            String correctedSentence = ws.isEmpty()
+                    ? originalSentence
+                    : applyWordCorrections(originalSentence, ws);
+
+            result.add(CorrectionEditorResponseDTO.Sentence.builder()
+                    .sentenceIdx(sentenceIdx)
+                    .originalText(originalSentence)
+                    .correctedText(correctedSentence)
+                    .build());
+        }
+
+        return result;
+    }
+
+    private String applyWordCorrections(String originalSentence, List<CorrectionWord> ws) {
+        StringBuilder sb = new StringBuilder();
+        int cursor = 0;
+
+        for (CorrectionWord w : ws) {
+            int start = clamp(w.getStartIdx(), 0, originalSentence.length());
+            int end = clamp(w.getEndIdx(), 0, originalSentence.length());
+            if (end < start) continue;
+
+            if (start > cursor) sb.append(originalSentence, cursor, start);
+
+            sb.append(w.getCorrectedText() == null ? "" : w.getCorrectedText());
+
+            cursor = end;
+        }
+
+        if (cursor < originalSentence.length()) {
+            sb.append(originalSentence.substring(cursor));
+        }
+
+        return sb.toString();
+    }
+
+    private int clamp(int v, int min, int max) {
+        return Math.max(min, Math.min(v, max));
     }
 
 

--- a/src/main/java/verbly/spring/domain/post/entity/Post.java
+++ b/src/main/java/verbly/spring/domain/post/entity/Post.java
@@ -3,6 +3,7 @@ package verbly.spring.domain.post.entity;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.Check;
+import verbly.spring.domain.correction.entity.Correction;
 import verbly.spring.domain.post.enums.PostStatus;
 import verbly.spring.domain.user.entity.User;
 import verbly.spring.global.common.entity.BaseEntity;
@@ -77,6 +78,12 @@ public class Post extends BaseEntity {
 
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Comment> comments = new ArrayList<>();
+
+    @OneToOne(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Correction correction;
+
+    @OneToOne(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private HotPost hotPost;
 
 
     public void update(String title, String content) {

--- a/src/main/java/verbly/spring/domain/user/entity/User.java
+++ b/src/main/java/verbly/spring/domain/user/entity/User.java
@@ -81,7 +81,7 @@ public class User extends BaseEntity {
     @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private Stats stats;
 
-    @OneToMany(mappedBy = "author")
+    @OneToMany(mappedBy = "author", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Post> posts;
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)


### PR DESCRIPTION
## #️⃣ 기능 설명
회원 탈퇴 시 post, correction 관련 테이블 데이터도 삭제하도록 엔티티에 매핑 추가, 상세 dto 첨삭된 문장도 추가
https://www.notion.so/3070a293a7b080d0811ae8f5ed4d892e?source=copy_link

## 🛠️ 작업 상세 내용
- [x]  엔티티에 매핑 추가
- [x] 첨삭된 문장도 반환하도록 추가

## 📸 스크린샷 (선택)

## 💬 기타(공유사항 to 리뷰어)
