### PR TITLE
🚀 [Perf] 사용자 정보 조회 성능 개선 by Redis 캐시 적용

### DIFF
--- a/src/main/java/verbly/spring/domain/user/service/UserCommandServiceImpl.java
+++ b/src/main/java/verbly/spring/domain/user/service/UserCommandServiceImpl.java
@@ -2,6 +2,7 @@ package verbly.spring.domain.user.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,6 +36,7 @@ public class UserCommandServiceImpl implements UserCommandService {
 
     @Override
     @Transactional // @Transactional에 의해 메서드 종료 시 변경 사항이 DB에 자동 반영
+    @CacheEvict(value = "user:info", key = "#userId")
     public User onboardingUser(Long userId, UserRequestDTO.OnboardingDTO request) {
         // 기존 회원이 존재하는지를 따짐
         User user = userRepository.findById(userId)
@@ -55,6 +57,7 @@ public class UserCommandServiceImpl implements UserCommandService {
 
     @Override
     @Transactional
+    @CacheEvict(value = "user:info", key = "#userId")
     public void deleteUser(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
@@ -73,6 +76,7 @@ public class UserCommandServiceImpl implements UserCommandService {
 
     @Override
     @Transactional
+    @CacheEvict(value = "user:info", key = "#userId")
     public UserResponseDTO.ProfileUpdateResultDTO updateUser(Long userId, UserRequestDTO.ProfileUpdateDTO request, MultipartFile profileImage) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));

--- a/src/main/java/verbly/spring/domain/user/service/UserQueryServiceImpl.java
+++ b/src/main/java/verbly/spring/domain/user/service/UserQueryServiceImpl.java
@@ -17,6 +17,7 @@ import verbly.spring.domain.user.repository.UserRepository;
 import verbly.spring.domain.user.validator.ProfileValidator;
 import verbly.spring.global.common.code.ErrorStatus;
 import verbly.spring.global.security.jwt.JwtTokenProvider;
+import org.springframework.cache.annotation.Cacheable;
 
 import java.time.LocalDateTime;
 
@@ -34,6 +35,7 @@ public class UserQueryServiceImpl implements UserQueryService {
 
     @Override
     @Transactional(readOnly = true)
+    @Cacheable(value = "user:info", key = "#userId")
     public UserResponseDTO.UserInfoDTO getUserInfo(Long userId){
 //        Authentication authentication = jwtTokenProvider.extractAuthentication(request); // 토큰을 파싱하고, Authentication 객체를 추출
 //        String socialId = authentication.getName(); // 추출해낸 인증 객체(Authentication)을 통해 사용자 정보를 가져온다.

--- a/src/main/java/verbly/spring/global/config/RedisConfig.java
+++ b/src/main/java/verbly/spring/global/config/RedisConfig.java
@@ -10,7 +10,6 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
-
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
@@ -30,6 +29,7 @@ public class RedisConfig {
         Map<String, RedisCacheConfiguration> perCache = new HashMap<>();
         // perCache.put("users:profile", base.entryTtl(Duration.ofSeconds(20))); // 최신 글은 짧게 캐시
         // 예시로 users:profile를 작성해놓은 것이니 수정 후 주석 풀고 필요한 부분 있으면 아래로 각자 파트 추가
+        perCache.put("user:info", base.entryTtl(Duration.ofMinutes(5)));
 
         return RedisCacheManager.builder(cf)
                 .cacheDefaults(base) // 기본 TTL 30초


### PR DESCRIPTION
## #️⃣ 기능 설명
> 사용자 정보 조회 API인 GET /api/user/me에 Redis 캐시를 적용하여 반복적인 DB 조회를 줄이고 조회 성능을 개선
기존에는 사용자 정보 조회 시 매 요청마다 DB 조회가 발생했지만, Redis 캐시를 적용하여 동일 사용자 조회 시 캐시 데이터를 반환하도록 개선

## 🛠️ 작업 상세 내용
- [x] UserQueryServiceImpl.getUserInfo()에 Redis 캐시 적용(@Cacheable)
- [x] UserCommandServiceImpl에서 캐시 무효화 처리(@CacheEvict)
- [x] RedisConfig에 userInfo 캐시 TTL 설정(5분)

## 📸 스크린샷 (선택)

## 💬 기타(공유사항 to 리뷰어)
Redis 캐시 적용 여부는 아래 순서로 확인 가능합니다.(총 5장 캡쳐 부탁)

1. Redis CLI 접속
Redis CLI에서 현재 캐시 상태를 확인하고, 현재 Redis 키 확인(keys *)
초기 상태에서는 아래와 같은 캐시 키가 없어야 정상입니다.
user:info::1
이 단계에서는 캡쳐 불필요
2. 최초 API 호출
Swagger에서 GET /api/user/me 호출(이 호출 시에는 Redis 캐시가 없기 때문에 DB 조회가 발생)
**Hibernate SQL 로그가 출력되는지 캡쳐** 한 번 부탁드려요.
3. Redis CLI에서 다시 Redis 키 확인
keys *
→ user:info::1 형태의 캐시 키 생성 확인
이 **키가 생성된 것 캡쳐** 부탁드려요!
4. TTL 확인
ttl user:info::1
→ 약 300초(5분) TTL 확인 가능
여기서 예를 들면, (integer) 296 이런거 **캡쳐 부탁**드립니다!
5. 동일 API 재호출
다시 GET /api/user/me 호출에서는 Redis 캐시가 사용되기 때문에 DB 조회가 발생하지 않음.
→ Redis 캐시가 사용되어 DB SQL 로그가 출력되지 않는 것을 확인할 수 있습니다. **두 번째 호출 시 SQL 로그가 없는 부분 캡쳐 부탁드립니다.**
6. Swagger 브라우저 Network 탭에서 첫 번째 호출 응답시간과 두 번째 호출 응답시간 비교 가능
**이 두가지 시간 비교를 확인할 수 있도록 캡쳐를 리뷰**로 달아주시면 감사하겠습니다!

(로컬 환경에서는 응답 속도 차이가 크지 않을 수 있으나, DB 조회 감소 효과를 확인할 수 있습니다.)